### PR TITLE
Clang does not need libgcc.a, it causes build to fail

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,7 +45,7 @@ add_subdirectory(freetype)
 include_directories(${CMAKE_CURRENT_BINARY_DIR})
 include_directories(freetype/include)
 
-if(${CMAKE_C_COMPILER_ID} STREQUAL "GNU" OR ${CMAKE_C_COMPILER_ID} STREQUAL "Clang")
+if(${CMAKE_C_COMPILER_ID} STREQUAL "GNU")
     target_link_libraries(quibble libgcc.a)
 endif()
 
@@ -123,7 +123,7 @@ set(SRC_FILES src/btrfs/btrfs.c
 
 add_executable(btrfs ${SRC_FILES})
 
-if(${CMAKE_C_COMPILER_ID} STREQUAL "GNU" OR ${CMAKE_C_COMPILER_ID} STREQUAL "Clang")
+if(${CMAKE_C_COMPILER_ID} STREQUAL "GNU")
     target_link_libraries(btrfs libgcc.a)
 endif()
 


### PR DESCRIPTION
I have tried to build Quibble with clang-mingw cross compiler (https://github.com/xt-sys/xtchain) and it fails because there was no libgcc.a available:

```
[ 68%] Linking C executable quibble.efi
lld: error: unable to find library -lgcc
clang-14: error: linker command failed with exit code 1 (use -v to see invocation)
```

After applying this small fix, build went just fine:

```$ cmake -DCMAKE_TOOLCHAIN_FILE=../clang-amd64.cmake ..
-- The C compiler identification is Clang 14.0.4
-- The CXX compiler identification is Clang 14.0.4
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - failed
-- Detecting C compile features
-- Detecting C compile features - done
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - failed
-- Detecting CXX compile features
-- Detecting CXX compile features - done
CMake Warning (dev) at freetype/CMakeLists.txt:129 (project):
  Policy CMP0048 is not set: project() command manages VERSION variables.
  Run "cmake --help-policy CMP0048" for policy details.  Use the cmake_policy
  command to set the policy and suppress this warning.

  The following variable(s) would be set to empty:

    PROJECT_VERSION
    PROJECT_VERSION_MAJOR
This warning is for project developers.  Use -Wno-dev to suppress it.

-- Looking for unistd.h
-- Looking for unistd.h - not found
-- Looking for fcntl.h
-- Looking for fcntl.h - not found
-- Looking for stdint.h
-- Looking for stdint.h - not found
CMake Warning (dev) at /opt/xtchain/share/cmake-3.23/Modules/GNUInstallDirs.cmake:241 (message):
  Unable to determine default CMAKE_INSTALL_LIBDIR directory because no
  target architecture is known.  Please enable at least one language before
  including GNUInstallDirs.
Call Stack (most recent call first):
  freetype/CMakeLists.txt:407 (include)
This warning is for project developers.  Use -Wno-dev to suppress it.

-- Configuring done
-- Generating done
-- Build files have been written to: /home/Belliash/quibble/build

$ make
[  1%] Building C object freetype/CMakeFiles/freetype.dir/src/autofit/autofit.c.o
[  3%] Building C object freetype/CMakeFiles/freetype.dir/src/base/ftbase.c.o
[  4%] Building C object freetype/CMakeFiles/freetype.dir/src/base/ftbbox.c.o
[  6%] Building C object freetype/CMakeFiles/freetype.dir/src/base/ftbdf.c.o
[  7%] Building C object freetype/CMakeFiles/freetype.dir/src/base/ftbitmap.c.o
[  9%] Building C object freetype/CMakeFiles/freetype.dir/src/base/ftcid.c.o
[ 10%] Building C object freetype/CMakeFiles/freetype.dir/src/base/ftfstype.c.o
[ 12%] Building C object freetype/CMakeFiles/freetype.dir/src/base/ftgasp.c.o
[ 13%] Building C object freetype/CMakeFiles/freetype.dir/src/base/ftglyph.c.o
[ 15%] Building C object freetype/CMakeFiles/freetype.dir/src/base/ftgxval.c.o
[ 16%] Building C object freetype/CMakeFiles/freetype.dir/src/base/ftinit.c.o
[ 18%] Building C object freetype/CMakeFiles/freetype.dir/src/base/ftmm.c.o
[ 19%] Building C object freetype/CMakeFiles/freetype.dir/src/base/ftotval.c.o
[ 21%] Building C object freetype/CMakeFiles/freetype.dir/src/base/ftpatent.c.o
[ 22%] Building C object freetype/CMakeFiles/freetype.dir/src/base/ftpfr.c.o
[ 24%] Building C object freetype/CMakeFiles/freetype.dir/src/base/ftstroke.c.o
[ 25%] Building C object freetype/CMakeFiles/freetype.dir/src/base/ftsynth.c.o
[ 27%] Building C object freetype/CMakeFiles/freetype.dir/src/base/fttype1.c.o
[ 28%] Building C object freetype/CMakeFiles/freetype.dir/src/base/ftwinfnt.c.o
[ 30%] Building C object freetype/CMakeFiles/freetype.dir/src/bzip2/ftbzip2.c.o
[ 31%] Building C object freetype/CMakeFiles/freetype.dir/src/cache/ftcache.c.o
[ 33%] Building C object freetype/CMakeFiles/freetype.dir/src/gzip/ftgzip.c.o
[ 34%] Building C object freetype/CMakeFiles/freetype.dir/src/lzw/ftlzw.c.o
[ 36%] Building C object freetype/CMakeFiles/freetype.dir/src/pcf/pcf.c.o
[ 37%] Building C object freetype/CMakeFiles/freetype.dir/src/pfr/pfr.c.o
[ 39%] Building C object freetype/CMakeFiles/freetype.dir/src/pshinter/pshinter.c.o
[ 40%] Building C object freetype/CMakeFiles/freetype.dir/src/raster/raster.c.o
[ 42%] Building C object freetype/CMakeFiles/freetype.dir/src/sfnt/sfnt.c.o
[ 43%] Building C object freetype/CMakeFiles/freetype.dir/src/smooth/smooth.c.o
[ 45%] Building C object freetype/CMakeFiles/freetype.dir/src/truetype/truetype.c.o
[ 46%] Building C object freetype/CMakeFiles/freetype.dir/src/winfonts/winfnt.c.o
[ 48%] Building C object freetype/CMakeFiles/freetype.dir/src/base/ftdebug.c.o
[ 50%] Linking C static library libfreetype.a
[ 50%] Built target freetype
[ 51%] Building C object CMakeFiles/quibble.dir/src/apiset.c.o
warning: unknown warning option '-Wno-packed-not-aligned'; did you mean '-Wno-over-aligned'? [-Wunknown-warning-option]
1 warning generated.
[ 53%] Building C object CMakeFiles/quibble.dir/src/boot.c.o
warning: unknown warning option '-Wno-packed-not-aligned'; did you mean '-Wno-over-aligned'? [-Wunknown-warning-option]
1 warning generated.
[ 54%] Building C object CMakeFiles/quibble.dir/src/debug.c.o
warning: unknown warning option '-Wno-packed-not-aligned'; did you mean '-Wno-over-aligned'? [-Wunknown-warning-option]
1 warning generated.
[ 56%] Building C object CMakeFiles/quibble.dir/src/hw.c.o
warning: unknown warning option '-Wno-packed-not-aligned'; did you mean '-Wno-over-aligned'? [-Wunknown-warning-option]
1 warning generated.
[ 57%] Building C object CMakeFiles/quibble.dir/src/mem.c.o
warning: unknown warning option '-Wno-packed-not-aligned'; did you mean '-Wno-over-aligned'? [-Wunknown-warning-option]
1 warning generated.
[ 59%] Building C object CMakeFiles/quibble.dir/src/menu.c.o
warning: unknown warning option '-Wno-packed-not-aligned'; did you mean '-Wno-over-aligned'? [-Wunknown-warning-option]
1 warning generated.
[ 60%] Building C object CMakeFiles/quibble.dir/src/misc.c.o
warning: unknown warning option '-Wno-packed-not-aligned'; did you mean '-Wno-over-aligned'? [-Wunknown-warning-option]
/home/Belliash/quibble/src/misc.c:144:9: warning: variable 'i' is incremented both in the loop header and in the loop body [-Wfor-loop-analysis]
        i++;
        ^
/home/Belliash/quibble/src/misc.c:124:28: note: incremented here
    for (int i = 0; i < n; i++) {
                           ^
/home/Belliash/quibble/src/misc.c:805:9: warning: variable 'i' is incremented both in the loop header and in the loop body [-Wfor-loop-analysis]
        i++;
        ^
/home/Belliash/quibble/src/misc.c:791:31: note: incremented here
    for (size_t i = 0; i < n; i++) {
                              ^
3 warnings generated.
[ 62%] Building C object CMakeFiles/quibble.dir/src/peload.c.o
warning: unknown warning option '-Wno-packed-not-aligned'; did you mean '-Wno-over-aligned'? [-Wunknown-warning-option]
/home/Belliash/quibble/src/peload.c:56:65: warning: expression which evaluates to zero treated as a null pointer constant of type 'void *' [-Wnon-literal-null-conversion]
    return bs->UninstallProtocolInterface(&pe_handle, &pe_guid, EFI_NATIVE_INTERFACE);
                                                                ^~~~~~~~~~~~~~~~~~~~
2 warnings generated.
[ 63%] Building C object CMakeFiles/quibble.dir/src/reg.c.o
warning: unknown warning option '-Wno-packed-not-aligned'; did you mean '-Wno-over-aligned'? [-Wunknown-warning-option]
/home/Belliash/quibble/src/reg.c:51:67: warning: expression which evaluates to zero treated as a null pointer constant of type 'void *' [-Wnon-literal-null-conversion]
    return bs->UninstallProtocolInterface(&reg_handle, &reg_guid, EFI_NATIVE_INTERFACE);
                                                                  ^~~~~~~~~~~~~~~~~~~~
/home/Belliash/quibble/src/reg.c:612:22: warning: variable 'ptr' is used uninitialized whenever 'if' condition is false [-Wsometimes-uninitialized]
            else if (datalen != 0)
                     ^~~~~~~~~~~~
/home/Belliash/quibble/src/reg.c:615:21: note: uninitialized use occurs here
            *Data = ptr;
                    ^~~
/home/Belliash/quibble/src/reg.c:612:18: note: remove the 'if' if its condition is always true
            else if (datalen != 0)
                 ^~~~~~~~~~~~~~~~~
/home/Belliash/quibble/src/reg.c:604:25: note: initialize the variable 'ptr' to silence this warning
            uint8_t* ptr;
                        ^
                         = NULL
3 warnings generated.
[ 65%] Building C object CMakeFiles/quibble.dir/src/tinymt32.c.o
warning: unknown warning option '-Wno-packed-not-aligned'; did you mean '-Wno-over-aligned'? [-Wunknown-warning-option]
1 warning generated.
[ 66%] Building C object CMakeFiles/quibble.dir/src/print.c.o
warning: unknown warning option '-Wno-packed-not-aligned'; did you mean '-Wno-over-aligned'? [-Wunknown-warning-option]
1 warning generated.
[ 68%] Linking C executable quibble.efi
[ 68%] Built target quibble
[ 69%] Building C object CMakeFiles/btrfs.dir/src/btrfs/btrfs.c.o
[ 71%] Building C object CMakeFiles/btrfs.dir/src/btrfs/crc32c.c.o
[ 72%] Building C object CMakeFiles/btrfs.dir/src/misc.c.o
[ 74%] Building C object CMakeFiles/btrfs.dir/src/btrfs/zlib/adler32.c.o
[ 75%] Building C object CMakeFiles/btrfs.dir/src/btrfs/zlib/deflate.c.o
[ 77%] Building C object CMakeFiles/btrfs.dir/src/btrfs/zlib/inffast.c.o
[ 78%] Building C object CMakeFiles/btrfs.dir/src/btrfs/zlib/inflate.c.o
[ 80%] Building C object CMakeFiles/btrfs.dir/src/btrfs/zlib/inftrees.c.o
[ 81%] Building C object CMakeFiles/btrfs.dir/src/btrfs/zlib/trees.c.o
[ 83%] Building C object CMakeFiles/btrfs.dir/src/btrfs/zlib/zutil.c.o
[ 84%] Building C object CMakeFiles/btrfs.dir/src/btrfs/lzo.c.o
[ 86%] Building C object CMakeFiles/btrfs.dir/src/btrfs/xxhash.c.o
[ 87%] Building C object CMakeFiles/btrfs.dir/src/btrfs/zstd/entropy_common.c.o
[ 89%] Building C object CMakeFiles/btrfs.dir/src/btrfs/zstd/error_private.c.o
[ 90%] Building C object CMakeFiles/btrfs.dir/src/btrfs/zstd/fse_decompress.c.o
[ 92%] Building C object CMakeFiles/btrfs.dir/src/btrfs/zstd/huf_decompress.c.o
[ 93%] Building C object CMakeFiles/btrfs.dir/src/btrfs/zstd/zstd_common.c.o
[ 95%] Building C object CMakeFiles/btrfs.dir/src/btrfs/zstd/zstd_ddict.c.o
[ 96%] Building C object CMakeFiles/btrfs.dir/src/btrfs/zstd/zstd_decompress.c.o
[ 98%] Building C object CMakeFiles/btrfs.dir/src/btrfs/zstd/zstd_decompress_block.c.o
[100%] Linking C executable btrfs.efi
[100%] Built target btrfs
```