### PR TITLE
Add CI Workflow for building debug versions when commit pushed

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -1,0 +1,37 @@
+name: CMake
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+
+env:
+  # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
+  BUILD_TYPE: Release
+
+jobs:
+  build:
+    # The CMake configure and build commands are platform agnostic and should work equally well on Windows or Mac.
+    # You can convert this to a matrix build if you need cross-platform coverage.
+    # See: https://docs.github.com/en/free-pro-team@latest/actions/learn-github-actions/managing-complex-workflows#using-a-build-matrix
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Configure CMake
+      # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
+      # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
+      run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
+
+    - name: Build
+      # Build your program with the given configuration
+      run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}}
+
+    - name: Test
+      working-directory: ${{github.workspace}}/build
+      # Execute tests defined by the CMake configuration.
+      # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
+      run: ctest -C ${{env.BUILD_TYPE}}
+

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -8,7 +8,7 @@ on:
 
 env:
   # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
-  BUILD_TYPE: Release
+  BUILD_TYPE: mingw-amd64.cmake
 
 jobs:
   build:

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -29,7 +29,7 @@ jobs:
         platform: x64
     
     - name: Install dependencies
-      run: apt install zlib1g-dev
+      run: sudo apt-get install -y zlib1g-dev
 
 
     - name: Configure CMake

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -22,6 +22,12 @@ jobs:
       with:
         ref: '6af4222daf646e294d362630e2740039ceb637df'
 
+    - name: Install MinGW
+      uses: egor-tensin/setup-mingw@v2.2.0
+      with:
+        platform: x64
+
+
     - name: Configure CMake
       # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
       # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -20,8 +20,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-      with:
-        ref: '6af4222daf646e294d362630e2740039ceb637df'
+    #   with:
+    #     ref: '6af4222daf646e294d362630e2740039ceb637df'
 
     - name: Install MinGW
       uses: egor-tensin/setup-mingw@v2.2.0

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -27,6 +27,9 @@ jobs:
       uses: egor-tensin/setup-mingw@v2.2.0
       with:
         platform: x64
+    
+    - name: Install dependencies
+      run: apt install zlib1g-dev
 
 
     - name: Configure CMake

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -9,6 +9,7 @@ on:
 env:
   # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
   TOOLCHAIN_TYPE: mingw-amd64.cmake
+  BUILD_TYPE: Release
 
 jobs:
   build:
@@ -31,7 +32,7 @@ jobs:
     - name: Configure CMake
       # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
       # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
-      run: cmake -B ${{github.workspace}}/build -DCMAKE_TOOLCHAIN_FILE=${{env.BUILD_TYPE}}
+      run: cmake -B ${{github.workspace}}/build -DCMAKE_TOOLCHAIN_FILE=${{env.TOOLCHAIN_TYPE}}
 
     - name: Build
       # Build your program with the given configuration

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -46,4 +46,9 @@ jobs:
       # Execute tests defined by the CMake configuration.
       # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
       run: ctest -C ${{env.BUILD_TYPE}}
-
+    - uses: actions/upload-artifact@v3
+      with:
+        name: quibble-debug
+        path: |
+          ${{github.workspace}}/build/quibble.efi
+          ${{github.workspace}}/build/btrfs.efi

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -9,7 +9,7 @@ on:
 env:
   # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
   TOOLCHAIN_TYPE: mingw-amd64.cmake
-  BUILD_TYPE: Release
+  BUILD_TYPE: Debug
 
 jobs:
   build:
@@ -48,7 +48,7 @@ jobs:
       run: ctest -C ${{env.BUILD_TYPE}}
     - uses: actions/upload-artifact@v3
       with:
-        name: quibble-debug
+        name: quibble-debug-x64
         path: |
           ${{github.workspace}}/build/quibble.efi
           ${{github.workspace}}/build/btrfs.efi

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -35,7 +35,7 @@ jobs:
     - name: Configure CMake
       # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
       # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
-      run: cd ${{github.workspace}}/build && cmake -DCMAKE_TOOLCHAIN_FILE=../${{env.TOOLCHAIN_TYPE}} ..
+      run: mkdir ${{github.workspace}}/build ; cd ${{github.workspace}}/build && cmake -DCMAKE_TOOLCHAIN_FILE=../${{env.TOOLCHAIN_TYPE}} ..
 
     - name: Build
       # Build your program with the given configuration

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -28,18 +28,18 @@ jobs:
       with:
         platform: x64
     
-    - name: Install dependencies
-      run: sudo apt-get install -y zlib1g-dev
+    # - name: Install dependencies
+    #   run: sudo apt-get install -y zlib1g-dev
 
 
     - name: Configure CMake
       # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
       # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
-      run: cmake -B ${{github.workspace}}/build -DCMAKE_TOOLCHAIN_FILE=${{env.TOOLCHAIN_TYPE}}
+      run: cd ${{github.workspace}}/build && cmake -DCMAKE_TOOLCHAIN_FILE=../${{env.TOOLCHAIN_TYPE}} ..
 
     - name: Build
       # Build your program with the given configuration
-      run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}}
+      run: cd ${{github.workspace}}/build && make 
 
     - name: Test
       working-directory: ${{github.workspace}}/build

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -8,7 +8,7 @@ on:
 
 env:
   # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
-  BUILD_TYPE: mingw-amd64.cmake
+  TOOLCHAIN_TYPE: mingw-amd64.cmake
 
 jobs:
   build:
@@ -31,7 +31,7 @@ jobs:
     - name: Configure CMake
       # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
       # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
-      run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
+      run: cmake -B ${{github.workspace}}/build -DCMAKE_TOOLCHAIN_FILE=${{env.BUILD_TYPE}}
 
     - name: Build
       # Build your program with the given configuration

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -19,6 +19,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
+      with:
+        ref: '6af4222daf646e294d362630e2740039ceb637df'
 
     - name: Configure CMake
       # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.

--- a/.github/workflows/mingw-amd64.yml
+++ b/.github/workflows/mingw-amd64.yml
@@ -1,4 +1,4 @@
-name: CMake
+name: Mingw-amd64
 
 on:
   push:
@@ -48,7 +48,7 @@ jobs:
       run: ctest -C ${{env.BUILD_TYPE}}
     - uses: actions/upload-artifact@v3
       with:
-        name: quibble-debug-x64
+        name: quibble-debug-x64-mingw
         path: |
           ${{github.workspace}}/build/quibble.efi
           ${{github.workspace}}/build/btrfs.efi

--- a/.github/workflows/mingw-x86.yml
+++ b/.github/workflows/mingw-x86.yml
@@ -1,0 +1,54 @@
+name: Mingw-x86
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+
+env:
+  # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
+  TOOLCHAIN_TYPE: mingw-x86.cmake
+  BUILD_TYPE: Debug
+
+jobs:
+  build:
+    # The CMake configure and build commands are platform agnostic and should work equally well on Windows or Mac.
+    # You can convert this to a matrix build if you need cross-platform coverage.
+    # See: https://docs.github.com/en/free-pro-team@latest/actions/learn-github-actions/managing-complex-workflows#using-a-build-matrix
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    #   with:
+    #     ref: '6af4222daf646e294d362630e2740039ceb637df'
+
+    - name: Install MinGW
+      uses: egor-tensin/setup-mingw@v2.2.0
+      with:
+        platform: x86
+    
+    # - name: Install dependencies
+    #   run: sudo apt-get install -y zlib1g-dev
+
+
+    - name: Configure CMake
+      # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
+      # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
+      run: mkdir ${{github.workspace}}/build ; cd ${{github.workspace}}/build && cmake -DCMAKE_TOOLCHAIN_FILE=../${{env.TOOLCHAIN_TYPE}} ..
+
+    - name: Build
+      # Build your program with the given configuration
+      run: cd ${{github.workspace}}/build && make 
+
+    - name: Test
+      working-directory: ${{github.workspace}}/build
+      # Execute tests defined by the CMake configuration.
+      # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
+      run: ctest -C ${{env.BUILD_TYPE}}
+    - uses: actions/upload-artifact@v3
+      with:
+        name: quibble-debug-x86-mingw
+        path: |
+          ${{github.workspace}}/build/quibble.efi
+          ${{github.workspace}}/build/btrfs.efi

--- a/freetype/builds/cmake/FindHarfBuzz.cmake
+++ b/freetype/builds/cmake/FindHarfBuzz.cmake
@@ -31,7 +31,7 @@
 # HARFBUZZ_LIBRARIES - containg the HarfBuzz library
 
 include(FindPkgConfig)
-pkg_check_modules(PC_HARFBUZZ QUIET harfbuzz)
+pkg_check_modules(PC_HARFBUZZ QUIET HarfBuzz)
 
 find_path(HARFBUZZ_INCLUDE_DIRS
     NAMES hb.h


### PR DESCRIPTION
I like quibble and want to try master builds without making the mess in my computer with mingw, compiling and etc, so i build this pipeline for github to make all work instead of curious user.