### PR TITLE
Fixed broken compiling on Linux.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,9 +58,6 @@ target_compile_definitions(harfbuzz PRIVATE -Dhb_malloc_impl=hb_malloc_impl2 -Dh
 target_compile_definitions(harfbuzz PRIVATE -DHB_TINY)
 target_compile_options(harfbuzz PRIVATE "-Wa,-mbig-obj")
 
-add_subdirectory(ntfs)
-add_subdirectory(btrfs)
-
 include_directories(${CMAKE_CURRENT_BINARY_DIR})
 include_directories(freetype/include)
 
@@ -72,6 +69,9 @@ if (${CMAKE_SYSTEM_PROCESSOR} STREQUAL "AMD64" OR ${CMAKE_SYSTEM_PROCESSOR} STRE
 elseif (${CMAKE_SYSTEM_PROCESSOR} STREQUAL "X86")
     include_directories(gnu-efi/ia32)
 endif()
+
+add_subdirectory(ntfs)
+add_subdirectory(btrfs)
 
 target_compile_options(quibble PRIVATE
      $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>,$<CXX_COMPILER_ID:GNU>>:

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ On Linux:
 
 * Install a cross-compiler, x86_64-w64-mingw32-gcc, and cmake.
 * Run the following:
-  * `git clone https://github.com/maharmstone/quibble`
+  * `git clone https://github.com/maharmstone/quibble --recurse-submodules`
   * `cd quibble`
   * `mkdir build`
   * `cd build`

--- a/gnu-efi/efi.h
+++ b/gnu-efi/efi.h
@@ -1,0 +1,82 @@
+/*++
+
+Copyright (c) 1998  Intel Corporation
+
+Module Name:
+
+    efi.h
+
+Abstract:
+
+    Public EFI header files
+
+
+
+Revision History
+
+--*/
+
+
+// Add a predefined macro to detect usage of the library
+#ifndef _GNU_EFI
+#define _GNU_EFI
+#endif
+
+//
+// Build flags on input
+//  EFI32
+//  EFI_DEBUG               - Enable debugging code
+//  EFI_NT_EMULATOR         - Building for running under NT
+//
+
+
+#ifndef _EFI_INCLUDE_
+#define _EFI_INCLUDE_
+
+#define EFI_FIRMWARE_VENDOR         L"INTEL"
+#define EFI_FIRMWARE_MAJOR_REVISION 12
+#define EFI_FIRMWARE_MINOR_REVISION 33
+#define EFI_FIRMWARE_REVISION ((EFI_FIRMWARE_MAJOR_REVISION <<16) | (EFI_FIRMWARE_MINOR_REVISION))
+
+#if defined(_M_X64) || defined(__x86_64__) || defined(__amd64__)
+#include "x86_64/efibind.h"
+#elif defined(_M_IX86) || defined(__i386__)
+#include "ia32/efibind.h"
+#elif defined(_M_IA64) || defined(__ia64__)
+#include "ia64/efibind.h"
+#elif defined (_M_ARM64) || defined(__aarch64__)
+#include "aarch64/efibind.h"
+#elif defined (_M_ARM) || defined(__arm__)
+#include "arm/efibind.h"
+#elif defined (_M_MIPS64) || defined(__mips64__) || defined(__mips64)
+#include "mips64el/efibind.h"
+#elif defined (__riscv) && __riscv_xlen == 64
+#include "riscv64/efibind.h"
+#elif defined (__loongarch64)
+#include "loongarch64/efibind.h"
+#else
+#error Usupported architecture
+#endif
+
+#include "eficompiler.h"
+#include "efidef.h"
+#include "efidevp.h"
+#include "efipciio.h"
+#include "efiprot.h"
+#include "eficon.h"
+#include "eficonex.h"
+#include "efiser.h"
+#include "efi_nii.h"
+#include "efipxebc.h"
+#include "efinet.h"
+#include "efiapi.h"
+#include "efifs.h"
+#include "efierr.h"
+#include "efiui.h"
+#include "efiip.h"
+#include "efiudp.h"
+#include "efitcp.h"
+#include "efipoint.h"
+#include "efishell.h"
+
+#endif

--- a/gnu-efi/efi_nii.h
+++ b/gnu-efi/efi_nii.h
@@ -1,0 +1,78 @@
+#ifndef _EFI_NII_H
+#define _EFI_NII_H
+
+/*++
+Copyright (c) 2000  Intel Corporation
+
+Module name:
+    efi_nii.h
+
+Abstract:
+
+Revision history:
+    2000-Feb-18 M(f)J   GUID updated.
+                Structure order changed for machine word alignment.
+                Added StringId[4] to structure.
+
+    2000-Feb-14 M(f)J   Genesis.
+--*/
+
+#define EFI_NETWORK_INTERFACE_IDENTIFIER_PROTOCOL_GUID \
+    { 0xE18541CD, 0xF755, 0x4f73, {0x92, 0x8D, 0x64, 0x3C, 0x8A, 0x79, 0xB2, 0x29} }
+
+#define EFI_NETWORK_INTERFACE_IDENTIFIER_PROTOCOL_REVISION  0x00010000
+#define EFI_NETWORK_INTERFACE_IDENTIFIER_INTERFACE_REVISION EFI_NETWORK_INTERFACE_IDENTIFIER_PROTOCOL_REVISION
+
+typedef enum {
+    EfiNetworkInterfaceUndi = 1
+} EFI_NETWORK_INTERFACE_TYPE;
+
+typedef struct _EFI_NETWORK_INTERFACE_IDENTIFIER_PROTOCOL {
+
+    UINT64 Revision;
+    // Revision of the network interface identifier protocol interface.
+
+    UINT64 ID;
+    // Address of the first byte of the identifying structure for this
+    // network interface.  This is set to zero if there is no structure.
+    //
+    // For PXE/UNDI this is the first byte of the !PXE structure.
+
+    UINT64 ImageAddr;
+    // Address of the UNrelocated driver/ROM image.  This is set
+    // to zero if there is no driver/ROM image.
+    //
+    // For 16-bit UNDI, this is the first byte of the option ROM in
+    // upper memory.
+    //
+    // For 32/64-bit S/W UNDI, this is the first byte of the EFI ROM
+    // image.
+    //
+    // For H/W UNDI, this is set to zero.
+
+    UINT32 ImageSize;
+    // Size of the UNrelocated driver/ROM image of this network interface.
+    // This is set to zero if there is no driver/ROM image.
+
+    CHAR8 StringId[4];
+    // 4 char ASCII string to go in class identifier (option 60) in DHCP
+    // and Boot Server discover packets.
+    // For EfiNetworkInterfaceUndi this field is "UNDI".
+    // For EfiNetworkInterfaceSnp this field is "SNPN".
+
+    UINT8 Type;
+    UINT8 MajorVer;
+    UINT8 MinorVer;
+    // Information to be placed into the PXE DHCP and Discover packets.
+    // This is the network interface type and version number that will
+    // be placed into DHCP option 94 (client network interface identifier).
+    BOOLEAN Ipv6Supported;
+    UINT8   IfNum;	// interface number to be used with pxeid structure
+} EFI_NETWORK_INTERFACE_IDENTIFIER_PROTOCOL, EFI_NETWORK_INTERFACE_IDENTIFIER_INTERFACE;
+
+// Note: Because it conflicted with the EDK2 struct name, the
+// 'EFI_NETWORK_INTERFACE_IDENTIFIER_PROTOCOL' GUID definition,
+// from older versions of gnu-efi, is now obsoleted.
+// Use 'EFI_NETWORK_INTERFACE_IDENTIFIER_PROTOCOL_GUID' instead.
+
+#endif // _EFI_NII_H

--- a/gnu-efi/eficompiler.h
+++ b/gnu-efi/eficompiler.h
@@ -1,0 +1,30 @@
+/*++
+
+Copyright (c) 2016 Pete Batard <pete@akeo.ie>
+
+Module Name:
+
+    eficompiler.h
+
+Abstract:
+
+    Compiler specific adjustments
+
+--*/
+
+#ifdef _MSC_EXTENSIONS
+#define EFI_UNUSED
+#else
+#define EFI_UNUSED __attribute__((__unused__))
+#endif
+
+#ifdef _MSC_EXTENSIONS
+#define ALIGN(x) __declspec(align(x))
+#else
+#define ALIGN(x) __attribute__((__aligned__(x)))
+#endif
+
+/* Also add a catch-all on __attribute__() for MS compilers */
+#ifdef _MSC_EXTENSIONS
+#define __attribute__(x)
+#endif

--- a/gnu-efi/eficonex.h
+++ b/gnu-efi/eficonex.h
@@ -1,0 +1,111 @@
+#ifndef _EFI_CONEX_H
+#define _EFI_CONEX_H
+
+/*++
+
+Copyright (c) 2020 Kagurazaka Kotori <kagurazakakotori@gmail.com>
+
+Module Name:
+
+    eficonex.h
+
+Abstract:
+
+    EFI console extension protocols
+
+--*/
+
+//
+// Simple Text Input Ex Protocol
+//
+
+#define EFI_SIMPLE_TEXT_INPUT_EX_PROTOCOL_GUID \
+    { 0xdd9e7534, 0x7762, 0x4698, {0x8c, 0x14, 0xf5, 0x85, 0x17, 0xa6, 0x25, 0xaa} }
+
+INTERFACE_DECL(_EFI_SIMPLE_TEXT_INPUT_EX_PROTOCOL);
+
+typedef UINT8 EFI_KEY_TOGGLE_STATE;
+
+typedef struct EFI_KEY_STATE {
+    UINT32                                         KeyShiftState;
+    EFI_KEY_TOGGLE_STATE                           KeyToggleState;
+} EFI_KEY_STATE;
+
+typedef struct {
+    EFI_INPUT_KEY                                  Key;
+    EFI_KEY_STATE                                  KeyState;
+} EFI_KEY_DATA;
+
+// Shift states
+#define EFI_SHIFT_STATE_VALID                      0x80000000
+#define EFI_RIGHT_SHIFT_PRESSED                    0x00000001
+#define EFI_LEFT_SHIFT_PRESSED                     0x00000002
+#define EFI_RIGHT_CONTROL_PRESSED                  0x00000004
+#define EFI_LEFT_CONTROL_PRESSED                   0x00000008
+#define EFI_RIGHT_ALT_PRESSED                      0x00000010
+#define EFI_LEFT_ALT_PRESSED                       0x00000020
+#define EFI_RIGHT_LOGO_PRESSED                     0x00000040
+#define EFI_LEFT_LOGO_PRESSED                      0x00000080
+#define EFI_MENU_KEY_PRESSED                       0x00000100
+#define EFI_SYS_REQ_PRESSED                        0x00000200
+
+// Toggle states
+#define EFI_TOGGLE_STATE_VALID                     0x80
+#define EFI_KEY_STATE_EXPOSED                      0x40
+#define EFI_SCROLL_LOCK_ACTIVE                     0x01
+#define EFI_NUM_LOCK_ACTIVE                        0x02
+#define EFI_CAPS_LOCK_ACTIVE                       0x04
+
+typedef
+EFI_STATUS
+(EFIAPI *EFI_INPUT_RESET_EX) (
+    IN struct _EFI_SIMPLE_TEXT_INPUT_EX_PROTOCOL   *This,
+    IN BOOLEAN                                     ExtendedVerification
+    );
+
+typedef
+EFI_STATUS
+(EFIAPI *EFI_INPUT_READ_KEY_EX) (
+    IN struct _EFI_SIMPLE_TEXT_INPUT_EX_PROTOCOL   *This,
+    OUT EFI_KEY_DATA                               *KeyData
+    );
+
+typedef
+EFI_STATUS
+(EFIAPI *EFI_SET_STATE) (
+    IN struct _EFI_SIMPLE_TEXT_INPUT_EX_PROTOCOL   *This,
+    IN EFI_KEY_TOGGLE_STATE                        *KeyToggleState
+    );
+
+typedef
+EFI_STATUS
+(EFIAPI *EFI_KEY_NOTIFY_FUNCTION) (
+    IN EFI_KEY_DATA                                *KeyData
+    );
+
+typedef
+EFI_STATUS
+(EFIAPI *EFI_REGISTER_KEYSTROKE_NOTIFY) (
+    IN struct _EFI_SIMPLE_TEXT_INPUT_EX_PROTOCOL   *This,
+    IN EFI_KEY_DATA                                *KeyData,
+    IN EFI_KEY_NOTIFY_FUNCTION                     KeyNotificationFunction,
+    OUT VOID                                       **NotifyHandle
+    );
+
+typedef
+EFI_STATUS
+(EFIAPI *EFI_UNREGISTER_KEYSTROKE_NOTIFY) (
+    IN struct _EFI_SIMPLE_TEXT_INPUT_EX_PROTOCOL   *This,
+    IN VOID                                        *NotificationHandle
+    );
+
+typedef struct _EFI_SIMPLE_TEXT_INPUT_EX_PROTOCOL{
+    EFI_INPUT_RESET_EX                             Reset;
+    EFI_INPUT_READ_KEY_EX                          ReadKeyStrokeEx;
+    EFI_EVENT                                      WaitForKeyEx;
+    EFI_SET_STATE                                  SetState;
+    EFI_REGISTER_KEYSTROKE_NOTIFY                  RegisterKeyNotify;
+    EFI_UNREGISTER_KEYSTROKE_NOTIFY                UnregisterKeyNotify;
+} EFI_SIMPLE_TEXT_INPUT_EX_PROTOCOL;
+
+#endif

--- a/gnu-efi/efifs.h
+++ b/gnu-efi/efifs.h
@@ -1,0 +1,116 @@
+#ifndef _EFI_FS_H
+#define _EFI_FS_H
+
+/*++
+
+Copyright (c) 1998  Intel Corporation
+
+Module Name:
+
+    efifs.h
+
+Abstract:
+
+    EFI File System structures
+
+
+
+Revision History
+
+--*/
+
+
+//
+// EFI Partition header (normaly starts in LBA 1)
+//
+
+#define EFI_PARTITION_SIGNATURE         0x5053595320494249
+#define EFI_PARTITION_REVISION          0x00010001
+#define MIN_EFI_PARTITION_BLOCK_SIZE    512
+#define EFI_PARTITION_LBA               1
+
+typedef struct _EFI_PARTITION_HEADER {
+    EFI_TABLE_HEADER    Hdr;
+    UINT32              DirectoryAllocationNumber;
+    UINT32              BlockSize;
+    EFI_LBA             FirstUsableLba;
+    EFI_LBA             LastUsableLba;
+    EFI_LBA             UnusableSpace;
+    EFI_LBA             FreeSpace;
+    EFI_LBA             RootFile;
+    EFI_LBA             SecutiryFile;
+} EFI_PARTITION_HEADER;
+
+
+//
+// File header
+//
+
+#define EFI_FILE_HEADER_SIGNATURE   0x454c494620494249
+#define EFI_FILE_HEADER_REVISION    0x00010000
+#define EFI_FILE_STRING_SIZE        260
+
+typedef struct _EFI_FILE_HEADER {
+    EFI_TABLE_HEADER    Hdr;
+    UINT32              Class;
+    UINT32              LBALOffset;
+    EFI_LBA             Parent;
+    UINT64              FileSize;
+    UINT64              FileAttributes;
+    EFI_TIME            FileCreateTime;
+    EFI_TIME            FileModificationTime;
+    EFI_GUID            VendorGuid;
+    CHAR16              FileString[EFI_FILE_STRING_SIZE];
+} EFI_FILE_HEADER;
+
+
+//
+// Return the file's first LBAL which is in the same
+// logical block as the file header
+//
+
+#define EFI_FILE_LBAL(a)    ((EFI_LBAL *) (((CHAR8 *) (a)) + (a)->LBALOffset))
+
+#define EFI_FILE_CLASS_FREE_SPACE   1
+#define EFI_FILE_CLASS_EMPTY        2
+#define EFI_FILE_CLASS_NORMAL       3
+
+
+//
+// Logical Block Address List - the fundemental block
+// description structure
+//
+
+#define EFI_LBAL_SIGNATURE      0x4c41424c20494249
+#define EFI_LBAL_REVISION       0x00010000
+
+typedef struct _EFI_LBAL {
+    EFI_TABLE_HEADER    Hdr;
+    UINT32              Class;
+    EFI_LBA             Parent;
+    EFI_LBA             Next;
+    UINT32              ArraySize;
+    UINT32              ArrayCount;
+} EFI_LBAL;
+
+// Array size 
+#define EFI_LBAL_ARRAY_SIZE(lbal,offs,blks)  \
+        (((blks) - (offs) - (lbal)->Hdr.HeaderSize) / sizeof(EFI_RL))
+
+//
+// Logical Block run-length
+//
+
+typedef struct {
+    EFI_LBA     Start;
+    UINT64      Length;
+} EFI_RL;
+
+//
+// Return the run-length structure from an LBAL header
+//
+
+#define EFI_LBAL_RL(a)      ((EFI_RL*) (((CHAR8 *) (a)) + (a)->Hdr.HeaderSize))
+
+#endif
+

--- a/gnu-efi/efiip.h
+++ b/gnu-efi/efiip.h
@@ -1,0 +1,459 @@
+#ifndef _EFI_IP_H
+#define _EFI_IP_H
+
+/*++
+Copyright (c) 2013  Intel Corporation
+
+--*/
+
+#define EFI_IP4_SERVICE_BINDING_PROTOCOL \
+   {0xc51711e7,0xb4bf,0x404a,{0xbf,0xb8,0x0a,0x04, 0x8e,0xf1,0xff,0xe4}}
+
+#define EFI_IP4_PROTOCOL \
+    {0x41d94cd2,0x35b6,0x455a,{0x82,0x58,0xd4,0xe5,0x13,0x34,0xaa,0xdd}}
+
+#define EFI_IP6_SERVICE_BINDING_PROTOCOL \
+    {0xec835dd3,0xfe0f,0x617b,{0xa6,0x21,0xb3,0x50,0xc3,0xe1,0x33,0x88}}
+
+#define EFI_IP6_PROTOCOL \
+    {0x2c8759d5,0x5c2d,0x66ef,{0x92,0x5f,0xb6,0x6c,0x10,0x19,0x57,0xe2}}
+
+INTERFACE_DECL(_EFI_IP4);
+INTERFACE_DECL(_EFI_IP6);
+
+typedef struct {
+    EFI_HANDLE       InstanceHandle;
+    EFI_IPv4_ADDRESS Ip4Address;
+    EFI_IPv4_ADDRESS SubnetMask;
+} EFI_IP4_ADDRESS_PAIR;
+
+typedef struct {
+    EFI_HANDLE           DriverHandle;
+    UINT32               AddressCount;
+    EFI_IP4_ADDRESS_PAIR AddressPairs[1];
+} EFI_IP4_VARIABLE_DATA;
+
+typedef struct {
+    UINT8            DefaultProtocol;
+    BOOLEAN          AcceptAnyProtocol;
+    BOOLEAN          AcceptIcmpErrors;
+    BOOLEAN          AcceptBroadcast;
+    BOOLEAN          AcceptPromiscuous;
+    BOOLEAN          UseDefaultAddress;
+    EFI_IPv4_ADDRESS StationAddress;
+    EFI_IPv4_ADDRESS SubnetMask;
+    UINT8            TypeOfService;
+    UINT8            TimeToLive;
+    BOOLEAN          DoNotFragment;
+    BOOLEAN          RawData;
+    UINT32           ReceiveTimeout;
+    UINT32           TransmitTimeout;
+} EFI_IP4_CONFIG_DATA;
+
+typedef struct {
+    EFI_IPv4_ADDRESS SubnetAddress;
+    EFI_IPv4_ADDRESS SubnetMask;
+    EFI_IPv4_ADDRESS GatewayAddress;
+} EFI_IP4_ROUTE_TABLE;
+
+typedef struct {
+    UINT8 Type;
+    UINT8 Code;
+} EFI_IP4_ICMP_TYPE;
+
+typedef struct {
+    BOOLEAN             IsStarted;
+    UINT32              MaxPacketSize;
+    EFI_IP4_CONFIG_DATA ConfigData;
+    BOOLEAN             IsConfigured;
+    UINT32              GroupCount;
+    EFI_IPv4_ADDRESS    *GroupTable;
+    UINT32              RouteCount;
+    EFI_IP4_ROUTE_TABLE *RouteTable;
+    UINT32              IcmpTypeCount;
+    EFI_IP4_ICMP_TYPE   *IcmpTypeList;
+} EFI_IP4_MODE_DATA;
+
+typedef
+EFI_STATUS
+(EFIAPI *EFI_IP4_GET_MODE_DATA) (
+    IN struct _EFI_IP4                  *This,
+    OUT EFI_IP4_MODE_DATA               *Ip4ModeData   OPTIONAL,
+    OUT EFI_MANAGED_NETWORK_CONFIG_DATA *MnpConfigData OPTIONAL,
+    OUT EFI_SIMPLE_NETWORK_MODE         *SnpModeData   OPTIONAL
+    );
+
+typedef
+EFI_STATUS
+(EFIAPI *EFI_IP4_CONFIGURE) (
+    IN struct _EFI_IP4     *This,
+    IN EFI_IP4_CONFIG_DATA *IpConfigData OPTIONAL
+    );
+
+typedef
+EFI_STATUS
+(EFIAPI *EFI_IP4_GROUPS) (
+    IN struct _EFI_IP4  *This,
+    IN BOOLEAN          JoinFlag,
+    IN EFI_IPv4_ADDRESS *GroupAddress OPTIONAL
+    );
+
+typedef
+EFI_STATUS
+(EFIAPI *EFI_IP4_ROUTES) (
+    IN struct _EFI_IP4  *This,
+    IN BOOLEAN          DeleteRoute,
+    IN EFI_IPv4_ADDRESS *SubnetAddress,
+    IN EFI_IPv4_ADDRESS *SubnetMask,
+    IN EFI_IPv4_ADDRESS *GatewayAddress
+    );
+
+#pragma pack(1)
+typedef struct {
+    UINT8            HeaderLength:4;
+    UINT8            Version:4;
+    UINT8            TypeOfService;
+    UINT16           TotalLength;
+    UINT16           Identification;
+    UINT16           Fragmentation;
+    UINT8            TimeToLive;
+    UINT8            Protocol;
+    UINT16           Checksum;
+    EFI_IPv4_ADDRESS SourceAddress;
+    EFI_IPv4_ADDRESS DestinationAddress;
+} EFI_IP4_HEADER;
+#pragma pack()
+
+typedef struct {
+    UINT32 FragmentLength;
+    VOID   *FragmentBuffer;
+} EFI_IP4_FRAGMENT_DATA;
+
+typedef struct {
+    EFI_TIME              TimeStamp;
+    EFI_EVENT             RecycleSignal;
+    UINT32                HeaderLength;
+    EFI_IP4_HEADER        *Header;
+    UINT32                OptionsLength;
+    VOID                  *Options;
+    UINT32                DataLength;
+    UINT32                FragmentCount;
+    EFI_IP4_FRAGMENT_DATA FragmentTable[1];
+} EFI_IP4_RECEIVE_DATA;
+
+typedef struct {
+    EFI_IPv4_ADDRESS SourceAddress;
+    EFI_IPv4_ADDRESS GatewayAddress;
+    UINT8            Protocol;
+    UINT8            TypeOfService;
+    UINT8            TimeToLive;
+    BOOLEAN          DoNotFragment;
+} EFI_IP4_OVERRIDE_DATA;
+
+typedef struct {
+    EFI_IPv4_ADDRESS      DestinationAddress;
+    EFI_IP4_OVERRIDE_DATA *OverrideData;
+    UINT32                OptionsLength;
+    VOID                  *OptionsBuffer;
+    UINT32                TotalDataLength;
+    UINT32                FragmentCount;
+    EFI_IP4_FRAGMENT_DATA FragmentTable[1];
+} EFI_IP4_TRANSMIT_DATA;
+
+typedef struct {
+    EFI_EVENT                 Event;
+    EFI_STATUS                Status;
+    union {
+        EFI_IP4_RECEIVE_DATA  *RxData;
+        EFI_IP4_TRANSMIT_DATA *TxData;
+    } Packet;
+} EFI_IP4_COMPLETION_TOKEN;
+
+typedef
+EFI_STATUS
+(EFIAPI *EFI_IP4_TRANSMIT) (
+    IN struct _EFI_IP4          *This,
+    IN EFI_IP4_COMPLETION_TOKEN *Token
+    );
+
+typedef
+EFI_STATUS
+(EFIAPI *EFI_IP4_RECEIVE) (
+    IN struct _EFI_IP4          *This,
+    IN EFI_IP4_COMPLETION_TOKEN *Token
+    );
+
+typedef
+EFI_STATUS
+(EFIAPI *EFI_IP4_CANCEL)(
+    IN struct _EFI_IP4          *This,
+    IN EFI_IP4_COMPLETION_TOKEN *Token OPTIONAL
+    );
+
+typedef
+EFI_STATUS
+(EFIAPI *EFI_IP4_POLL) (
+    IN struct _EFI_IP4 *This
+    );
+
+typedef struct _EFI_IP4 {
+    EFI_IP4_GET_MODE_DATA GetModeData;
+    EFI_IP4_CONFIGURE     Configure;
+    EFI_IP4_GROUPS        Groups;
+    EFI_IP4_ROUTES        Routes;
+    EFI_IP4_TRANSMIT      Transmit;
+    EFI_IP4_RECEIVE       Receive;
+    EFI_IP4_CANCEL        Cancel;
+    EFI_IP4_POLL          Poll;
+} EFI_IP4;
+
+typedef struct {
+    UINT8            DefaultProtocol;
+    BOOLEAN          AcceptAnyProtocol;
+    BOOLEAN          AcceptIcmpErrors;
+    BOOLEAN          AcceptPromiscuous;
+    EFI_IPv6_ADDRESS DestinationAddress;
+    EFI_IPv6_ADDRESS StationAddress;
+    UINT8            TrafficClass;
+    UINT8            HopLimit;
+    UINT32           FlowLabel;
+    UINT32           ReceiveTimeout;
+    UINT32           TransmitTimeout;
+} EFI_IP6_CONFIG_DATA;
+
+typedef struct {
+    EFI_IPv6_ADDRESS Address;
+    UINT8            PrefixLength;
+} EFI_IP6_ADDRESS_INFO;
+
+typedef struct {
+    EFI_IPv6_ADDRESS Gateway;
+    EFI_IPv6_ADDRESS Destination;
+    UINT8            PrefixLength;
+} EFI_IP6_ROUTE_TABLE;
+
+typedef enum {
+    EfiNeighborInComplete,
+    EfiNeighborReachable,
+    EfiNeighborStale,
+    EfiNeighborDelay,
+    EfiNeighborProbe
+} EFI_IP6_NEIGHBOR_STATE;
+
+typedef struct {
+    EFI_IPv6_ADDRESS       Neighbor;
+    EFI_MAC_ADDRESS        LinkAddress;
+    EFI_IP6_NEIGHBOR_STATE State;
+} EFI_IP6_NEIGHBOR_CACHE;
+
+typedef struct {
+    UINT8 Type;
+    UINT8 Code;
+} EFI_IP6_ICMP_TYPE;
+
+//***********************************************************
+// ICMPv6 type definitions for error messages
+//***********************************************************
+#define ICMP_V6_DEST_UNREACHABLE     0x1
+#define ICMP_V6_PACKET_TOO_BIG       0x2
+#define ICMP_V6_TIME_EXCEEDED        0x3
+#define ICMP_V6_PARAMETER_PROBLEM    0x4
+
+//***********************************************************
+// ICMPv6 type definition for informational messages
+//***********************************************************
+#define ICMP_V6_ECHO_REQUEST         0x80
+#define ICMP_V6_ECHO_REPLY           0x81
+#define ICMP_V6_LISTENER_QUERY       0x82
+#define ICMP_V6_LISTENER_REPORT      0x83
+#define ICMP_V6_LISTENER_DONE        0x84
+#define ICMP_V6_ROUTER_SOLICIT       0x85
+#define ICMP_V6_ROUTER_ADVERTISE     0x86
+#define ICMP_V6_NEIGHBOR_SOLICIT     0x87
+#define ICMP_V6_NEIGHBOR_ADVERTISE   0x88
+#define ICMP_V6_REDIRECT             0x89
+#define ICMP_V6_LISTENER_REPORT_2    0x8F
+
+//***********************************************************
+// ICMPv6 code definitions for ICMP_V6_DEST_UNREACHABLE
+//***********************************************************
+#define ICMP_V6_NO_ROUTE_TO_DEST     0x0
+#define ICMP_V6_COMM_PROHIBITED      0x1
+#define ICMP_V6_BEYOND_SCOPE         0x2
+#define ICMP_V6_ADDR_UNREACHABLE     0x3
+#define ICMP_V6_PORT_UNREACHABLE     0x4
+#define ICMP_V6_SOURCE_ADDR_FAILED   0x5
+#define ICMP_V6_ROUTE_REJECTED       0x6
+
+//***********************************************************
+// ICMPv6 code definitions for ICMP_V6_TIME_EXCEEDED
+//***********************************************************
+#define ICMP_V6_TIMEOUT_HOP_LIMIT    0x0
+#define ICMP_V6_TIMEOUT_REASSEMBLE   0x1
+
+//***********************************************************
+// ICMPv6 code definitions for ICMP_V6_PARAMETER_PROBLEM
+//***********************************************************
+#define ICMP_V6_ERRONEOUS_HEADER     0x0
+#define ICMP_V6_UNRECOGNIZE_NEXT_HDR 0x1
+#define ICMP_V6_UNRECOGNIZE_OPTION   0x2
+
+typedef struct {
+    BOOLEAN                IsStarted;
+    UINT32                 MaxPacketSize;
+    EFI_IP6_CONFIG_DATA    ConfigData;
+    BOOLEAN                IsConfigured;
+    UINT32                 AddressCount;
+    EFI_IP6_ADDRESS_INFO   *AddressList;
+    UINT32                 GroupCount;
+    EFI_IPv6_ADDRESS       *GroupTable;
+    UINT32                 RouteCount;
+    EFI_IP6_ROUTE_TABLE    *RouteTable;
+    UINT32                 NeighborCount;
+    EFI_IP6_NEIGHBOR_CACHE *NeighborCache;
+    UINT32                 PrefixCount;
+    EFI_IP6_ADDRESS_INFO   *PrefixTable;
+    UINT32                 IcmpTypeCount;
+    EFI_IP6_ICMP_TYPE      *IcmpTypeList;
+} EFI_IP6_MODE_DATA;
+
+typedef
+EFI_STATUS
+(EFIAPI *EFI_IP6_GET_MODE_DATA) (
+    IN struct _EFI_IP6                  *This,
+    OUT EFI_IP6_MODE_DATA               *Ip6ModeData   OPTIONAL,
+    OUT EFI_MANAGED_NETWORK_CONFIG_DATA *MnpConfigData OPTIONAL,
+    OUT EFI_SIMPLE_NETWORK_MODE         *SnpModeData   OPTIONAL
+    );
+
+typedef
+EFI_STATUS
+(EFIAPI *EFI_IP6_CONFIGURE) (
+    IN struct _EFI_IP6     *This,
+    IN EFI_IP6_CONFIG_DATA *Ip6ConfigData OPTIONAL
+    );
+typedef
+EFI_STATUS
+(EFIAPI *EFI_IP6_GROUPS) (
+    IN struct _EFI_IP6  *This,
+    IN BOOLEAN          JoinFlag,
+    IN EFI_IPv6_ADDRESS *GroupAddress OPTIONAL
+    );
+
+typedef
+EFI_STATUS
+(EFIAPI *EFI_IP6_ROUTES) (
+    IN struct _EFI_IP6  *This,
+    IN BOOLEAN          DeleteRoute,
+    IN EFI_IPv6_ADDRESS *Destination    OPTIONAL,
+    IN UINT8            PrefixLength,
+    IN EFI_IPv6_ADDRESS *GatewayAddress OPTIONAL
+    );
+
+typedef
+EFI_STATUS
+(EFIAPI *EFI_IP6_NEIGHBORS) (
+    IN struct _EFI_IP6  *This,
+    IN BOOLEAN          DeleteFlag,
+    IN EFI_IPv6_ADDRESS *TargetIp6Address,
+    IN EFI_MAC_ADDRESS  *TargetLinkAddress OPTIONAL,
+    IN UINT32           Timeout,
+    IN BOOLEAN          Override
+    );
+
+typedef struct _EFI_IP6_FRAGMENT_DATA {
+    UINT32 FragmentLength;
+    VOID   *FragmentBuffer;
+} EFI_IP6_FRAGMENT_DATA;
+
+typedef struct _EFI_IP6_OVERRIDE_DATA {
+    UINT8  Protocol;
+    UINT8  HopLimit;
+    UINT32 FlowLabel;
+} EFI_IP6_OVERRIDE_DATA;
+
+typedef struct _EFI_IP6_TRANSMIT_DATA {
+    EFI_IPv6_ADDRESS      DestinationAddress;
+    EFI_IP6_OVERRIDE_DATA *OverrideData;
+    UINT32                ExtHdrsLength;
+    VOID                  *ExtHdrs;
+    UINT8                 NextHeader;
+    UINT32                DataLength;
+    UINT32                FragmentCount;
+    EFI_IP6_FRAGMENT_DATA FragmentTable[1];
+} EFI_IP6_TRANSMIT_DATA;
+
+#pragma pack(1)
+typedef struct _EFI_IP6_HEADER {
+    UINT8            TrafficClassH:4;
+    UINT8            Version:4;
+    UINT8            FlowLabelH:4;
+    UINT8            TrafficClassL:4;
+    UINT16           FlowLabelL;
+    UINT16           PayloadLength;
+    UINT8            NextHeader;
+    UINT8            HopLimit;
+    EFI_IPv6_ADDRESS SourceAddress;
+    EFI_IPv6_ADDRESS DestinationAddress;
+} EFI_IP6_HEADER;
+#pragma pack()
+
+typedef struct _EFI_IP6_RECEIVE_DATA {
+    EFI_TIME              TimeStamp;
+    EFI_EVENT             RecycleSignal;
+    UINT32                HeaderLength;
+    EFI_IP6_HEADER        *Header;
+    UINT32                DataLength;
+    UINT32                FragmentCount;
+    EFI_IP6_FRAGMENT_DATA FragmentTable[1];
+} EFI_IP6_RECEIVE_DATA;
+
+typedef struct {
+    EFI_EVENT                 Event;
+    EFI_STATUS                Status;
+    union {
+	EFI_IP6_RECEIVE_DATA  *RxData;
+	EFI_IP6_TRANSMIT_DATA *TxData;
+    }                         Packet;
+} EFI_IP6_COMPLETION_TOKEN;
+
+typedef
+EFI_STATUS
+(EFIAPI *EFI_IP6_TRANSMIT) (
+    IN struct _EFI_IP6          *This,
+    IN EFI_IP6_COMPLETION_TOKEN *Token
+    );
+
+typedef
+EFI_STATUS
+(EFIAPI *EFI_IP6_RECEIVE) (
+    IN struct _EFI_IP6          *This,
+    IN EFI_IP6_COMPLETION_TOKEN *Token
+    );
+
+typedef
+EFI_STATUS
+(EFIAPI *EFI_IP6_CANCEL)(
+    IN struct _EFI_IP6          *This,
+    IN EFI_IP6_COMPLETION_TOKEN *Token OPTIONAL
+    );
+
+typedef
+EFI_STATUS
+(EFIAPI *EFI_IP6_POLL) (
+    IN struct _EFI_IP6 *This
+    );
+
+typedef struct _EFI_IP6 {
+    EFI_IP6_GET_MODE_DATA GetModeData;
+    EFI_IP6_CONFIGURE     Configure;
+    EFI_IP6_GROUPS        Groups;
+    EFI_IP6_ROUTES        Routes;
+    EFI_IP6_NEIGHBORS     Neighbors;
+    EFI_IP6_TRANSMIT      Transmit;
+    EFI_IP6_RECEIVE       Receive;
+    EFI_IP6_CANCEL        Cancel;
+    EFI_IP6_POLL          Poll;
+} EFI_IP6;
+
+#endif /* _EFI_IP_H */

--- a/gnu-efi/efinet.h
+++ b/gnu-efi/efinet.h
@@ -1,0 +1,348 @@
+#ifndef _EFINET_H
+#define _EFINET_H
+
+
+/*++
+Copyright (c) 1999  Intel Corporation
+
+Module Name:
+    efinet.h
+
+Abstract:
+    EFI Simple Network protocol
+
+Revision History
+--*/
+
+
+///////////////////////////////////////////////////////////////////////////////
+//
+//      Simple Network Protocol
+//
+
+#define EFI_SIMPLE_NETWORK_PROTOCOL_GUID \
+    { 0xA19832B9, 0xAC25, 0x11D3, {0x9A, 0x2D, 0x00, 0x90, 0x27, 0x3F, 0xC1, 0x4D} }
+
+INTERFACE_DECL(_EFI_SIMPLE_NETWORK_PROTOCOL);
+
+///////////////////////////////////////////////////////////////////////////////
+//
+
+typedef struct {
+    //
+    // Total number of frames received.  Includes frames with errors and
+    // dropped frames.
+    //
+    UINT64  RxTotalFrames;
+
+    //
+    // Number of valid frames received and copied into receive buffers.
+    //
+    UINT64  RxGoodFrames;
+
+    //
+    // Number of frames below the minimum length for the media.
+    // This would be <64 for ethernet.
+    //
+    UINT64  RxUndersizeFrames;
+
+    //
+    // Number of frames longer than the maxminum length for the
+    // media.  This would be >1500 for ethernet.
+    //
+    UINT64  RxOversizeFrames;
+
+    //
+    // Valid frames that were dropped because receive buffers were full.
+    //
+    UINT64  RxDroppedFrames;
+
+    //
+    // Number of valid unicast frames received and not dropped.
+    //
+    UINT64  RxUnicastFrames;
+
+    //
+    // Number of valid broadcast frames received and not dropped.
+    //
+    UINT64  RxBroadcastFrames;
+
+    //
+    // Number of valid mutlicast frames received and not dropped.
+    //
+    UINT64  RxMulticastFrames;
+
+    //
+    // Number of frames w/ CRC or alignment errors.
+    //
+    UINT64  RxCrcErrorFrames;
+
+    //
+    // Total number of bytes received.  Includes frames with errors
+    // and dropped frames.
+    //
+    UINT64  RxTotalBytes;
+
+    //
+    // Transmit statistics.
+    //
+    UINT64  TxTotalFrames;
+    UINT64  TxGoodFrames;
+    UINT64  TxUndersizeFrames;
+    UINT64  TxOversizeFrames;
+    UINT64  TxDroppedFrames;
+    UINT64  TxUnicastFrames;
+    UINT64  TxBroadcastFrames;
+    UINT64  TxMulticastFrames;
+    UINT64  TxCrcErrorFrames;
+    UINT64  TxTotalBytes;
+
+    //
+    // Number of collisions detection on this subnet.
+    //
+    UINT64  Collisions;
+
+    //
+    // Number of frames destined for unsupported protocol.
+    //
+    UINT64  UnsupportedProtocol;
+
+} EFI_NETWORK_STATISTICS;
+
+///////////////////////////////////////////////////////////////////////////////
+//
+
+typedef enum {
+    EfiSimpleNetworkStopped,
+    EfiSimpleNetworkStarted,
+    EfiSimpleNetworkInitialized,
+    EfiSimpleNetworkMaxState
+} EFI_SIMPLE_NETWORK_STATE;
+
+///////////////////////////////////////////////////////////////////////////////
+//
+
+#define EFI_SIMPLE_NETWORK_RECEIVE_UNICAST               0x01
+#define EFI_SIMPLE_NETWORK_RECEIVE_MULTICAST             0x02
+#define EFI_SIMPLE_NETWORK_RECEIVE_BROADCAST             0x04
+#define EFI_SIMPLE_NETWORK_RECEIVE_PROMISCUOUS           0x08
+#define EFI_SIMPLE_NETWORK_RECEIVE_PROMISCUOUS_MULTICAST 0x10
+
+///////////////////////////////////////////////////////////////////////////////
+//
+
+#define EFI_SIMPLE_NETWORK_RECEIVE_INTERRUPT        0x01
+#define EFI_SIMPLE_NETWORK_TRANSMIT_INTERRUPT       0x02
+#define EFI_SIMPLE_NETWORK_COMMAND_INTERRUPT        0x04
+#define EFI_SIMPLE_NETWORK_SOFTWARE_INTERRUPT       0x08
+
+///////////////////////////////////////////////////////////////////////////////
+//
+#define MAX_MCAST_FILTER_CNT    16
+typedef struct {
+    UINT32                      State;
+    UINT32                      HwAddressSize;
+    UINT32                      MediaHeaderSize;
+    UINT32                      MaxPacketSize;
+    UINT32                      NvRamSize;
+    UINT32                      NvRamAccessSize;
+    UINT32                      ReceiveFilterMask;
+    UINT32                      ReceiveFilterSetting;
+    UINT32                      MaxMCastFilterCount;
+    UINT32                      MCastFilterCount;
+    EFI_MAC_ADDRESS             MCastFilter[MAX_MCAST_FILTER_CNT];
+    EFI_MAC_ADDRESS             CurrentAddress;
+    EFI_MAC_ADDRESS             BroadcastAddress;
+    EFI_MAC_ADDRESS             PermanentAddress;
+    UINT8                       IfType;
+    BOOLEAN                     MacAddressChangeable;
+    BOOLEAN                     MultipleTxSupported;
+    BOOLEAN                     MediaPresentSupported;
+    BOOLEAN                     MediaPresent;
+} EFI_SIMPLE_NETWORK_MODE;
+
+///////////////////////////////////////////////////////////////////////////////
+//
+
+typedef
+EFI_STATUS
+(EFIAPI *EFI_SIMPLE_NETWORK_START) (
+    IN struct _EFI_SIMPLE_NETWORK_PROTOCOL  *This
+);
+
+///////////////////////////////////////////////////////////////////////////////
+//
+
+typedef
+EFI_STATUS
+(EFIAPI *EFI_SIMPLE_NETWORK_STOP) (
+    IN struct _EFI_SIMPLE_NETWORK_PROTOCOL  *This
+);
+
+///////////////////////////////////////////////////////////////////////////////
+//
+
+typedef
+EFI_STATUS
+(EFIAPI *EFI_SIMPLE_NETWORK_INITIALIZE) (
+    IN struct _EFI_SIMPLE_NETWORK_PROTOCOL  *This,
+    IN UINTN                                ExtraRxBufferSize  OPTIONAL,
+    IN UINTN                                ExtraTxBufferSize  OPTIONAL
+);
+
+///////////////////////////////////////////////////////////////////////////////
+//
+
+typedef
+EFI_STATUS
+(EFIAPI *EFI_SIMPLE_NETWORK_RESET) (
+    IN struct _EFI_SIMPLE_NETWORK_PROTOCOL  *This,
+    IN BOOLEAN                              ExtendedVerification
+);
+
+///////////////////////////////////////////////////////////////////////////////
+//
+
+typedef
+EFI_STATUS
+(EFIAPI *EFI_SIMPLE_NETWORK_SHUTDOWN) (
+    IN struct _EFI_SIMPLE_NETWORK_PROTOCOL  *This
+);
+
+///////////////////////////////////////////////////////////////////////////////
+//
+
+typedef
+EFI_STATUS
+(EFIAPI *EFI_SIMPLE_NETWORK_RECEIVE_FILTERS) (
+    IN struct _EFI_SIMPLE_NETWORK_PROTOCOL  *This,
+    IN UINT32                               Enable,
+    IN UINT32                               Disable,
+    IN BOOLEAN                              ResetMCastFilter,
+    IN UINTN                                MCastFilterCnt     OPTIONAL,
+    IN EFI_MAC_ADDRESS                      *MCastFilter       OPTIONAL
+);
+
+///////////////////////////////////////////////////////////////////////////////
+//
+
+typedef
+EFI_STATUS
+(EFIAPI *EFI_SIMPLE_NETWORK_STATION_ADDRESS) (
+    IN struct _EFI_SIMPLE_NETWORK_PROTOCOL  *This,
+    IN BOOLEAN                              Reset,
+    IN EFI_MAC_ADDRESS                      *New      OPTIONAL
+);
+
+///////////////////////////////////////////////////////////////////////////////
+//
+
+typedef
+EFI_STATUS
+(EFIAPI *EFI_SIMPLE_NETWORK_STATISTICS) (
+    IN struct _EFI_SIMPLE_NETWORK_PROTOCOL  *This,
+    IN BOOLEAN                              Reset,
+    IN OUT UINTN                            *StatisticsSize   OPTIONAL,
+    OUT EFI_NETWORK_STATISTICS              *StatisticsTable  OPTIONAL
+);
+
+///////////////////////////////////////////////////////////////////////////////
+//
+
+typedef
+EFI_STATUS
+(EFIAPI *EFI_SIMPLE_NETWORK_MCAST_IP_TO_MAC) (
+    IN struct _EFI_SIMPLE_NETWORK_PROTOCOL  *This,
+    IN BOOLEAN                              IPv6,
+    IN EFI_IP_ADDRESS                       *IP,
+    OUT EFI_MAC_ADDRESS                     *MAC
+);
+
+///////////////////////////////////////////////////////////////////////////////
+//
+
+typedef
+EFI_STATUS
+(EFIAPI *EFI_SIMPLE_NETWORK_NVDATA) (
+    IN struct _EFI_SIMPLE_NETWORK_PROTOCOL  *This,
+    IN BOOLEAN                              ReadWrite,
+    IN UINTN                                Offset,
+    IN UINTN                                BufferSize,
+    IN OUT VOID                             *Buffer
+);
+
+///////////////////////////////////////////////////////////////////////////////
+//
+
+typedef
+EFI_STATUS
+(EFIAPI *EFI_SIMPLE_NETWORK_GET_STATUS) (
+    IN struct _EFI_SIMPLE_NETWORK_PROTOCOL  *This,
+    OUT UINT32                              *InterruptStatus  OPTIONAL,
+    OUT VOID                                **TxBuf           OPTIONAL
+);
+
+///////////////////////////////////////////////////////////////////////////////
+//
+
+typedef
+EFI_STATUS
+(EFIAPI *EFI_SIMPLE_NETWORK_TRANSMIT) (
+    IN struct _EFI_SIMPLE_NETWORK_PROTOCOL  *This,
+    IN UINTN                                HeaderSize,
+    IN UINTN                                BufferSize,
+    IN VOID                                 *Buffer,
+    IN EFI_MAC_ADDRESS                      *SrcAddr     OPTIONAL,
+    IN EFI_MAC_ADDRESS                      *DestAddr    OPTIONAL,
+    IN UINT16                               *Protocol    OPTIONAL
+);
+
+///////////////////////////////////////////////////////////////////////////////
+//
+
+typedef
+EFI_STATUS
+(EFIAPI *EFI_SIMPLE_NETWORK_RECEIVE) (
+    IN struct _EFI_SIMPLE_NETWORK_PROTOCOL  *This,
+    OUT UINTN                               *HeaderSize  OPTIONAL,
+    IN OUT UINTN                            *BufferSize,
+    OUT VOID                                *Buffer,
+    OUT EFI_MAC_ADDRESS                     *SrcAddr     OPTIONAL,
+    OUT EFI_MAC_ADDRESS                     *DestAddr    OPTIONAL,
+    OUT UINT16                              *Protocol    OPTIONAL
+);
+
+///////////////////////////////////////////////////////////////////////////////
+//
+
+#define EFI_SIMPLE_NETWORK_PROTOCOL_REVISION  0x00010000
+#define EFI_SIMPLE_NETWORK_INTERFACE_REVISION EFI_SIMPLE_NETWORK_PROTOCOL_REVISION
+
+typedef struct _EFI_SIMPLE_NETWORK_PROTOCOL {
+    UINT64                              Revision;
+    EFI_SIMPLE_NETWORK_START            Start;
+    EFI_SIMPLE_NETWORK_STOP             Stop;
+    EFI_SIMPLE_NETWORK_INITIALIZE       Initialize;
+    EFI_SIMPLE_NETWORK_RESET            Reset;
+    EFI_SIMPLE_NETWORK_SHUTDOWN         Shutdown;
+    EFI_SIMPLE_NETWORK_RECEIVE_FILTERS  ReceiveFilters;
+    EFI_SIMPLE_NETWORK_STATION_ADDRESS  StationAddress;
+    EFI_SIMPLE_NETWORK_STATISTICS       Statistics;
+    EFI_SIMPLE_NETWORK_MCAST_IP_TO_MAC  MCastIpToMac;
+    EFI_SIMPLE_NETWORK_NVDATA           NvData;
+    EFI_SIMPLE_NETWORK_GET_STATUS       GetStatus;
+    EFI_SIMPLE_NETWORK_TRANSMIT         Transmit;
+    EFI_SIMPLE_NETWORK_RECEIVE          Receive;
+    EFI_EVENT                           WaitForPacket;
+    EFI_SIMPLE_NETWORK_MODE             *Mode;
+} EFI_SIMPLE_NETWORK_PROTOCOL;
+
+// Note: Because it conflicted with the EDK2 struct name, the
+// 'EFI_SIMPLE_NETWORK_PROTOCOL' GUID definition, from older
+// versions of gnu-efi, is now obsoleted.
+// Use 'EFI_SIMPLE_NETWORK_PROTOCOL_GUID' instead.
+
+typedef struct _EFI_SIMPLE_NETWORK_PROTOCOL _EFI_SIMPLE_NETWORK;
+typedef EFI_SIMPLE_NETWORK_PROTOCOL EFI_SIMPLE_NETWORK;
+
+#endif /* _EFINET_H */

--- a/gnu-efi/efipoint.h
+++ b/gnu-efi/efipoint.h
@@ -1,0 +1,115 @@
+/* Copyright (C) 2014 by John Cronin
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#ifndef _EFI_POINT_H
+#define _EFI_POINT_H
+
+#define EFI_SIMPLE_POINTER_PROTOCOL_GUID \
+	{ 0x31878c87, 0xb75, 0x11d5, { 0x9a, 0x4f, 0x0, 0x90, 0x27, 0x3f, 0xc1, 0x4d } }
+
+INTERFACE_DECL(_EFI_SIMPLE_POINTER);
+
+typedef struct {
+	INT32 RelativeMovementX;
+	INT32 RelativeMovementY;
+	INT32 RelativeMovementZ;
+	BOOLEAN LeftButton;
+	BOOLEAN RightButton;
+} EFI_SIMPLE_POINTER_STATE;
+
+typedef struct {
+	UINT64 ResolutionX;
+	UINT64 ResolutionY;
+	UINT64 ResolutionZ;
+	BOOLEAN LeftButton;
+	BOOLEAN RightButton;
+} EFI_SIMPLE_POINTER_MODE;
+
+typedef
+EFI_STATUS
+(EFIAPI *EFI_SIMPLE_POINTER_RESET) (
+	IN struct _EFI_SIMPLE_POINTER *This,
+	IN BOOLEAN ExtendedVerification
+);
+
+typedef
+EFI_STATUS
+(EFIAPI *EFI_SIMPLE_POINTER_GET_STATE) (
+	IN struct _EFI_SIMPLE_POINTER *This,
+	IN OUT EFI_SIMPLE_POINTER_STATE *State
+);
+
+typedef struct _EFI_SIMPLE_POINTER {
+	EFI_SIMPLE_POINTER_RESET Reset;
+	EFI_SIMPLE_POINTER_GET_STATE GetState;
+	EFI_EVENT WaitForInput;
+	EFI_SIMPLE_POINTER_MODE *Mode;
+} EFI_SIMPLE_POINTER_PROTOCOL;
+
+#define EFI_ABSOLUTE_POINTER_PROTOCOL_GUID \
+	{ 0x8D59D32B, 0xC655, 0x4AE9, { 0x9B, 0x15, 0xF2, 0x59, 0x04, 0x99, 0x2A, 0x43 } }
+
+INTERFACE_DECL(_EFI_ABSOLUTE_POINTER_PROTOCOL);
+
+typedef struct {
+	UINT64 AbsoluteMinX;
+	UINT64 AbsoluteMinY;
+	UINT64 AbsoluteMinZ;
+	UINT64 AbsoluteMaxX;
+	UINT64 AbsoluteMaxY;
+	UINT64 AbsoluteMaxZ;
+	UINT32 Attributes;
+} EFI_ABSOLUTE_POINTER_MODE;
+
+typedef struct {
+	UINT64 CurrentX;
+	UINT64 CurrentY;
+	UINT64 CurrentZ;
+	UINT32 ActiveButtons;
+} EFI_ABSOLUTE_POINTER_STATE;
+
+#define EFI_ABSP_SupportsAltActive 0x00000001
+#define EFI_ABSP_SupportsPressureAsZ 0x00000002
+#define EFI_ABSP_TouchActive 0x00000001
+#define EFI_ABS_AltActive 0x00000002
+
+typedef
+EFI_STATUS
+(EFIAPI *EFI_ABSOLUTE_POINTER_RESET) (
+	IN struct _EFI_ABSOLUTE_POINTER_PROTOCOL *This,
+	IN BOOLEAN ExtendedVerification
+);
+
+typedef
+EFI_STATUS
+(EFIAPI *EFI_ABSOLUTE_POINTER_GET_STATE) (
+	IN struct _EFI_ABSOLUTE_POINTER_PROTOCOL *This,
+	IN OUT EFI_ABSOLUTE_POINTER_STATE *State
+);
+
+typedef struct _EFI_ABSOLUTE_POINTER_PROTOCOL {
+	EFI_ABSOLUTE_POINTER_RESET Reset;
+	EFI_ABSOLUTE_POINTER_GET_STATE GetState;
+	EFI_EVENT WaitForInput;
+	EFI_ABSOLUTE_POINTER_MODE *Mode;
+} EFI_ABSOLUTE_POINTER_PROTOCOL;
+
+#endif

--- a/gnu-efi/efipxebc.h
+++ b/gnu-efi/efipxebc.h
@@ -1,0 +1,482 @@
+#ifndef _EFIPXEBC_H
+#define _EFIPXEBC_H
+
+/*++
+
+Copyright (c) 1998  Intel Corporation
+
+Module Name:
+
+    efipxebc.h
+
+Abstract:
+
+    EFI PXE Base Code Protocol
+
+
+
+Revision History
+
+--*/
+
+//
+// PXE Base Code protocol
+//
+
+#define EFI_PXE_BASE_CODE_PROTOCOL_GUID \
+    { 0x03c4e603, 0xac28, 0x11d3, {0x9a, 0x2d, 0x00, 0x90, 0x27, 0x3f, 0xc1, 0x4d} }
+
+INTERFACE_DECL(_EFI_PXE_BASE_CODE_PROTOCOL);
+
+#define DEFAULT_TTL 4
+#define DEFAULT_ToS 0
+//
+// Address definitions
+//
+
+typedef union {
+    UINT32      Addr[4];
+    EFI_IPv4_ADDRESS    v4;
+    EFI_IPv6_ADDRESS    v6;
+} EFI_IP_ADDRESS;
+
+typedef UINT16 EFI_PXE_BASE_CODE_UDP_PORT;
+
+//
+// Packet definitions
+//
+
+typedef struct {
+    UINT8                           BootpOpcode;
+    UINT8                           BootpHwType;
+    UINT8                           BootpHwAddrLen;
+    UINT8                           BootpGateHops;
+    UINT32                          BootpIdent;
+    UINT16                          BootpSeconds;
+    UINT16                          BootpFlags;
+    UINT8                           BootpCiAddr[4];
+    UINT8                           BootpYiAddr[4];
+    UINT8                           BootpSiAddr[4];
+    UINT8                           BootpGiAddr[4];
+    UINT8                           BootpHwAddr[16];
+    UINT8                           BootpSrvName[64];
+    UINT8                           BootpBootFile[128];
+    UINT32                          DhcpMagik;
+    UINT8                           DhcpOptions[56];
+} EFI_PXE_BASE_CODE_DHCPV4_PACKET;
+
+typedef struct {
+    UINT32                          MessageType:8;
+    UINT32                          TransactionId:24;
+    UINT8                           DhcpOptions[1024];
+} EFI_PXE_BASE_CODE_DHCPV6_PACKET;
+
+typedef union {
+    UINT8                               Raw[1472];
+    EFI_PXE_BASE_CODE_DHCPV4_PACKET     Dhcpv4;
+    EFI_PXE_BASE_CODE_DHCPV6_PACKET     Dhcpv6;
+} EFI_PXE_BASE_CODE_PACKET;
+
+typedef struct {
+    UINT8                   Type;
+    UINT8                   Code;
+    UINT16                  Checksum;
+    union {
+        UINT32              reserved;
+        UINT32              Mtu;
+        UINT32              Pointer;
+        struct {
+            UINT16          Identifier;
+            UINT16          Sequence;
+        } Echo;
+    } u;
+    UINT8                   Data[494];
+} EFI_PXE_BASE_CODE_ICMP_ERROR;
+
+typedef struct {
+    UINT8                   ErrorCode;
+    CHAR8                   ErrorString[127];
+} EFI_PXE_BASE_CODE_TFTP_ERROR;
+
+//
+// IP Receive Filter definitions
+//
+#define EFI_PXE_BASE_CODE_MAX_IPCNT             8
+typedef struct {
+    UINT8                       Filters;
+    UINT8                       IpCnt;
+    UINT16                      reserved;
+    EFI_IP_ADDRESS              IpList[EFI_PXE_BASE_CODE_MAX_IPCNT];
+} EFI_PXE_BASE_CODE_IP_FILTER;
+
+#define EFI_PXE_BASE_CODE_IP_FILTER_STATION_IP             0x0001
+#define EFI_PXE_BASE_CODE_IP_FILTER_BROADCAST              0x0002
+#define EFI_PXE_BASE_CODE_IP_FILTER_PROMISCUOUS            0x0004
+#define EFI_PXE_BASE_CODE_IP_FILTER_PROMISCUOUS_MULTICAST  0x0008
+
+//
+// ARP Cache definitions
+//
+
+typedef struct {
+    EFI_IP_ADDRESS       IpAddr;
+    EFI_MAC_ADDRESS      MacAddr;
+} EFI_PXE_BASE_CODE_ARP_ENTRY;
+
+typedef struct {
+    EFI_IP_ADDRESS       IpAddr;
+    EFI_IP_ADDRESS       SubnetMask;
+    EFI_IP_ADDRESS       GwAddr;
+} EFI_PXE_BASE_CODE_ROUTE_ENTRY;
+
+//
+// UDP definitions
+//
+
+#define EFI_PXE_BASE_CODE_UDP_OPFLAGS_ANY_SRC_IP    0x0001
+#define EFI_PXE_BASE_CODE_UDP_OPFLAGS_ANY_SRC_PORT  0x0002
+#define EFI_PXE_BASE_CODE_UDP_OPFLAGS_ANY_DEST_IP   0x0004
+#define EFI_PXE_BASE_CODE_UDP_OPFLAGS_ANY_DEST_PORT 0x0008
+#define EFI_PXE_BASE_CODE_UDP_OPFLAGS_USE_FILTER    0x0010
+#define EFI_PXE_BASE_CODE_UDP_OPFLAGS_MAY_FRAGMENT  0x0020
+
+//
+// Discover() definitions
+//
+
+#define EFI_PXE_BASE_CODE_BOOT_TYPE_BOOTSTRAP           0
+#define EFI_PXE_BASE_CODE_BOOT_TYPE_MS_WINNT_RIS        1
+#define EFI_PXE_BASE_CODE_BOOT_TYPE_INTEL_LCM           2
+#define EFI_PXE_BASE_CODE_BOOT_TYPE_DOSUNDI             3
+#define EFI_PXE_BASE_CODE_BOOT_TYPE_NEC_ESMPRO          4
+#define EFI_PXE_BASE_CODE_BOOT_TYPE_IBM_WSoD            5
+#define EFI_PXE_BASE_CODE_BOOT_TYPE_IBM_LCCM            6
+#define EFI_PXE_BASE_CODE_BOOT_TYPE_CA_UNICENTER_TNG    7
+#define EFI_PXE_BASE_CODE_BOOT_TYPE_HP_OPENVIEW         8
+#define EFI_PXE_BASE_CODE_BOOT_TYPE_ALTIRIS_9           9
+#define EFI_PXE_BASE_CODE_BOOT_TYPE_ALTIRIS_10          10
+#define EFI_PXE_BASE_CODE_BOOT_TYPE_ALTIRIS_11          11
+#define EFI_PXE_BASE_CODE_BOOT_TYPE_NOT_USED_12         12
+#define EFI_PXE_BASE_CODE_BOOT_TYPE_REDHAT_INSTALL      13
+#define EFI_PXE_BASE_CODE_BOOT_TYPE_REDHAT_BOOT         14
+#define EFI_PXE_BASE_CODE_BOOT_TYPE_REMBO               15
+#define EFI_PXE_BASE_CODE_BOOT_TYPE_BEOBOOT             16
+//
+// 17 through 32767 are reserved
+// 32768 through 65279 are for vendor use
+// 65280 through 65534 are reserved
+//
+#define EFI_PXE_BASE_CODE_BOOT_TYPE_PXETEST             65535
+
+#define EFI_PXE_BASE_CODE_BOOT_LAYER_MASK               0x7FFF
+#define EFI_PXE_BASE_CODE_BOOT_LAYER_INITIAL            0x0000
+
+
+typedef struct {
+    UINT16                      Type;
+    BOOLEAN                     AcceptAnyResponse;
+    UINT8                       Reserved;
+    EFI_IP_ADDRESS              IpAddr;
+} EFI_PXE_BASE_CODE_SRVLIST;
+
+typedef struct {
+    BOOLEAN                     UseMCast;
+    BOOLEAN                     UseBCast;
+    BOOLEAN                     UseUCast;
+    BOOLEAN                     MustUseList;
+    EFI_IP_ADDRESS              ServerMCastIp;
+    UINT16                      IpCnt;
+    EFI_PXE_BASE_CODE_SRVLIST   SrvList[1];
+} EFI_PXE_BASE_CODE_DISCOVER_INFO;
+
+//
+// Mtftp() definitions
+//
+
+typedef enum {
+    EFI_PXE_BASE_CODE_TFTP_FIRST,
+    EFI_PXE_BASE_CODE_TFTP_GET_FILE_SIZE,
+    EFI_PXE_BASE_CODE_TFTP_READ_FILE,
+    EFI_PXE_BASE_CODE_TFTP_WRITE_FILE,
+    EFI_PXE_BASE_CODE_TFTP_READ_DIRECTORY,
+    EFI_PXE_BASE_CODE_MTFTP_GET_FILE_SIZE,
+    EFI_PXE_BASE_CODE_MTFTP_READ_FILE,
+    EFI_PXE_BASE_CODE_MTFTP_READ_DIRECTORY,
+    EFI_PXE_BASE_CODE_MTFTP_LAST
+} EFI_PXE_BASE_CODE_TFTP_OPCODE;
+
+typedef struct {
+    EFI_IP_ADDRESS   MCastIp;
+    EFI_PXE_BASE_CODE_UDP_PORT  CPort;
+    EFI_PXE_BASE_CODE_UDP_PORT  SPort;
+    UINT16                      ListenTimeout;
+    UINT16                      TransmitTimeout;
+} EFI_PXE_BASE_CODE_MTFTP_INFO;
+
+//
+// PXE Base Code Mode structure
+//
+
+#define EFI_PXE_BASE_CODE_MAX_ARP_ENTRIES       8
+#define EFI_PXE_BASE_CODE_MAX_ROUTE_ENTRIES     8
+
+typedef struct {
+    BOOLEAN                         Started;
+    BOOLEAN                         Ipv6Available;
+    BOOLEAN                         Ipv6Supported;
+    BOOLEAN                         UsingIpv6;
+    BOOLEAN                         BisSupported;
+    BOOLEAN                         BisDetected;
+    BOOLEAN                         AutoArp;
+    BOOLEAN                         SendGUID;
+    BOOLEAN                         DhcpDiscoverValid;
+    BOOLEAN                         DhcpAckReceived;
+    BOOLEAN                         ProxyOfferReceived;
+    BOOLEAN                         PxeDiscoverValid;
+    BOOLEAN                         PxeReplyReceived;
+    BOOLEAN                         PxeBisReplyReceived;
+    BOOLEAN                         IcmpErrorReceived;
+    BOOLEAN                         TftpErrorReceived;
+    BOOLEAN                         MakeCallbacks;
+    UINT8                           TTL;
+    UINT8                           ToS;
+    EFI_IP_ADDRESS                  StationIp;
+    EFI_IP_ADDRESS                  SubnetMask;
+    EFI_PXE_BASE_CODE_PACKET        DhcpDiscover;
+    EFI_PXE_BASE_CODE_PACKET        DhcpAck;
+    EFI_PXE_BASE_CODE_PACKET        ProxyOffer;
+    EFI_PXE_BASE_CODE_PACKET        PxeDiscover;
+    EFI_PXE_BASE_CODE_PACKET        PxeReply;
+    EFI_PXE_BASE_CODE_PACKET        PxeBisReply;
+    EFI_PXE_BASE_CODE_IP_FILTER     IpFilter;
+    UINT32                          ArpCacheEntries;
+    EFI_PXE_BASE_CODE_ARP_ENTRY     ArpCache[EFI_PXE_BASE_CODE_MAX_ARP_ENTRIES];
+    UINT32                          RouteTableEntries;
+    EFI_PXE_BASE_CODE_ROUTE_ENTRY   RouteTable[EFI_PXE_BASE_CODE_MAX_ROUTE_ENTRIES];
+    EFI_PXE_BASE_CODE_ICMP_ERROR    IcmpError;
+    EFI_PXE_BASE_CODE_TFTP_ERROR    TftpError;
+} EFI_PXE_BASE_CODE_MODE;
+
+//
+// PXE Base Code Interface Function definitions
+//
+
+typedef
+EFI_STATUS
+(EFIAPI *EFI_PXE_BASE_CODE_START) (
+    IN struct _EFI_PXE_BASE_CODE_PROTOCOL  *This,
+    IN BOOLEAN                             UseIpv6
+    );
+
+typedef
+EFI_STATUS
+(EFIAPI *EFI_PXE_BASE_CODE_STOP) (
+    IN struct _EFI_PXE_BASE_CODE_PROTOCOL  *This
+    );
+
+typedef
+EFI_STATUS
+(EFIAPI *EFI_PXE_BASE_CODE_DHCP) (
+    IN struct _EFI_PXE_BASE_CODE_PROTOCOL  *This,
+    IN BOOLEAN                             SortOffers
+    );
+
+typedef
+EFI_STATUS
+(EFIAPI *EFI_PXE_BASE_CODE_DISCOVER) (
+    IN struct _EFI_PXE_BASE_CODE_PROTOCOL   *This,
+    IN UINT16                               Type,
+    IN UINT16                               *Layer,
+    IN BOOLEAN                              UseBis,
+    IN OUT EFI_PXE_BASE_CODE_DISCOVER_INFO  *Info   OPTIONAL
+    );
+
+typedef
+EFI_STATUS
+(EFIAPI *EFI_PXE_BASE_CODE_MTFTP) (
+    IN struct _EFI_PXE_BASE_CODE_PROTOCOL  *This,
+    IN EFI_PXE_BASE_CODE_TFTP_OPCODE       Operation,
+    IN OUT VOID                            *BufferPtr  OPTIONAL,
+    IN BOOLEAN                             Overwrite,
+    IN OUT UINT64                          *BufferSize,
+    IN UINTN                               *BlockSize  OPTIONAL,
+    IN EFI_IP_ADDRESS                      *ServerIp,
+    IN UINT8                               *Filename,
+    IN EFI_PXE_BASE_CODE_MTFTP_INFO        *Info       OPTIONAL,
+    IN BOOLEAN                             DontUseBuffer
+    );
+
+typedef
+EFI_STATUS
+(EFIAPI *EFI_PXE_BASE_CODE_UDP_WRITE) (
+    IN struct _EFI_PXE_BASE_CODE_PROTOCOL  *This,
+    IN UINT16                              OpFlags,
+    IN EFI_IP_ADDRESS                      *DestIp,
+    IN EFI_PXE_BASE_CODE_UDP_PORT          *DestPort,
+    IN EFI_IP_ADDRESS                      *GatewayIp,  OPTIONAL
+    IN EFI_IP_ADDRESS                      *SrcIp,      OPTIONAL
+    IN OUT EFI_PXE_BASE_CODE_UDP_PORT      *SrcPort,    OPTIONAL
+    IN UINTN                               *HeaderSize, OPTIONAL
+    IN VOID                                *HeaderPtr,  OPTIONAL
+    IN UINTN                               *BufferSize,
+    IN VOID                                *BufferPtr
+    );
+
+typedef
+EFI_STATUS
+(EFIAPI *EFI_PXE_BASE_CODE_UDP_READ) (
+    IN struct _EFI_PXE_BASE_CODE_PROTOCOL  *This,
+    IN UINT16                              OpFlags,
+    IN OUT EFI_IP_ADDRESS                  *DestIp,      OPTIONAL
+    IN OUT EFI_PXE_BASE_CODE_UDP_PORT      *DestPort,    OPTIONAL
+    IN OUT EFI_IP_ADDRESS                  *SrcIp,       OPTIONAL
+    IN OUT EFI_PXE_BASE_CODE_UDP_PORT      *SrcPort,     OPTIONAL
+    IN UINTN                               *HeaderSize,  OPTIONAL
+    IN VOID                                *HeaderPtr,   OPTIONAL
+    IN OUT UINTN                           *BufferSize,
+    IN VOID                                *BufferPtr
+    );
+
+typedef
+EFI_STATUS
+(EFIAPI *EFI_PXE_BASE_CODE_SET_IP_FILTER) (
+    IN struct _EFI_PXE_BASE_CODE_PROTOCOL  *This,
+    IN EFI_PXE_BASE_CODE_IP_FILTER         *NewFilter
+    );
+
+typedef
+EFI_STATUS
+(EFIAPI *EFI_PXE_BASE_CODE_ARP) (
+    IN struct _EFI_PXE_BASE_CODE_PROTOCOL  *This,
+    IN EFI_IP_ADDRESS                      *IpAddr,
+    IN EFI_MAC_ADDRESS                     *MacAddr      OPTIONAL
+    );
+
+typedef
+EFI_STATUS
+(EFIAPI *EFI_PXE_BASE_CODE_SET_PARAMETERS) (
+    IN struct _EFI_PXE_BASE_CODE_PROTOCOL  *This,
+    IN BOOLEAN                             *NewAutoArp,    OPTIONAL
+    IN BOOLEAN                             *NewSendGUID,   OPTIONAL
+    IN UINT8                               *NewTTL,        OPTIONAL
+    IN UINT8                               *NewToS,        OPTIONAL
+    IN BOOLEAN                             *NewMakeCallback    OPTIONAL
+    );
+
+typedef
+EFI_STATUS
+(EFIAPI *EFI_PXE_BASE_CODE_SET_STATION_IP) (
+    IN struct _EFI_PXE_BASE_CODE_PROTOCOL  *This,
+    IN EFI_IP_ADDRESS                      *NewStationIp,  OPTIONAL
+    IN EFI_IP_ADDRESS                      *NewSubnetMask  OPTIONAL
+    );
+
+typedef
+EFI_STATUS
+(EFIAPI *EFI_PXE_BASE_CODE_SET_PACKETS) (
+    IN struct _EFI_PXE_BASE_CODE_PROTOCOL  *This,
+    BOOLEAN                                *NewDhcpDiscoverValid,  OPTIONAL
+    BOOLEAN                                *NewDhcpAckReceived,    OPTIONAL
+    BOOLEAN                                *NewProxyOfferReceived, OPTIONAL
+    BOOLEAN                                *NewPxeDiscoverValid,   OPTIONAL
+    BOOLEAN                                *NewPxeReplyReceived,   OPTIONAL
+    BOOLEAN                                *NewPxeBisReplyReceived,OPTIONAL
+    IN EFI_PXE_BASE_CODE_PACKET            *NewDhcpDiscover, OPTIONAL
+    IN EFI_PXE_BASE_CODE_PACKET            *NewDhcpAck,      OPTIONAL
+    IN EFI_PXE_BASE_CODE_PACKET            *NewProxyOffer,   OPTIONAL
+    IN EFI_PXE_BASE_CODE_PACKET            *NewPxeDiscover,  OPTIONAL
+    IN EFI_PXE_BASE_CODE_PACKET            *NewPxeReply,     OPTIONAL
+    IN EFI_PXE_BASE_CODE_PACKET            *NewPxeBisReply   OPTIONAL
+    );
+
+//
+// PXE Base Code Protocol structure
+//
+
+#define EFI_PXE_BASE_CODE_PROTOCOL_REVISION  0x00010000
+#define EFI_PXE_BASE_CODE_INTERFACE_REVISION EFI_PXE_BASE_CODE_PROTOCOL_REVISION
+
+typedef struct _EFI_PXE_BASE_CODE_PROTOCOL {
+    UINT64                              Revision;
+    EFI_PXE_BASE_CODE_START             Start;
+    EFI_PXE_BASE_CODE_STOP              Stop;
+    EFI_PXE_BASE_CODE_DHCP              Dhcp;
+    EFI_PXE_BASE_CODE_DISCOVER          Discover;
+    EFI_PXE_BASE_CODE_MTFTP             Mtftp;
+    EFI_PXE_BASE_CODE_UDP_WRITE         UdpWrite;
+    EFI_PXE_BASE_CODE_UDP_READ          UdpRead;
+    EFI_PXE_BASE_CODE_SET_IP_FILTER     SetIpFilter;
+    EFI_PXE_BASE_CODE_ARP               Arp;
+    EFI_PXE_BASE_CODE_SET_PARAMETERS    SetParameters;
+    EFI_PXE_BASE_CODE_SET_STATION_IP    SetStationIp;
+    EFI_PXE_BASE_CODE_SET_PACKETS       SetPackets;
+    EFI_PXE_BASE_CODE_MODE              *Mode;
+} EFI_PXE_BASE_CODE_PROTOCOL;
+
+// Note: Because it conflicted with the EDK2 struct name, the
+// 'EFI_PXE_BASE_CODE_PROTOCOL' GUID definition, from older
+// versions of gnu-efi, is now obsoleted.
+// Use 'EFI_PXE_BASE_CODE_PROTOCOL_GUID' instead.
+
+typedef struct _EFI_PXE_BASE_CODE_PROTOCOL _EFI_PXE_BASE_CODE;
+typedef struct _EFI_PXE_BASE_CODE_PROTOCOL EFI_PXE_BASE_CODE;
+
+//
+// Call Back Definitions
+//
+
+#define EFI_PXE_BASE_CODE_CALLBACK_PROTOCOL_GUID \
+    { 0x245dca21, 0xfb7b, 0x11d3, {0x8f, 0x01, 0x00, 0xa0, 0xc9, 0x69, 0x72, 0x3b} }
+
+//
+// Revision Number
+//
+
+#define EFI_PXE_BASE_CODE_CALLBACK_PROTOCOL_REVISION  0x00010000
+#define EFI_PXE_BASE_CODE_CALLBACK_INTERFACE_REVISION EFI_PXE_BASE_CODE_CALLBACK_PROTOCOL_REVISION
+
+INTERFACE_DECL(_EFI_PXE_BASE_CODE_CALLBACK_PROTOCOL);
+
+typedef enum {
+    EFI_PXE_BASE_CODE_FUNCTION_FIRST,
+    EFI_PXE_BASE_CODE_FUNCTION_DHCP,
+    EFI_PXE_BASE_CODE_FUNCTION_DISCOVER,
+    EFI_PXE_BASE_CODE_FUNCTION_MTFTP,
+    EFI_PXE_BASE_CODE_FUNCTION_UDP_WRITE,
+    EFI_PXE_BASE_CODE_FUNCTION_UDP_READ,
+    EFI_PXE_BASE_CODE_FUNCTION_ARP,
+    EFI_PXE_BASE_CODE_FUNCTION_IGMP,
+    EFI_PXE_BASE_CODE_PXE_FUNCTION_LAST
+} EFI_PXE_BASE_CODE_FUNCTION;
+
+typedef enum {
+    EFI_PXE_BASE_CODE_CALLBACK_STATUS_FIRST,
+    EFI_PXE_BASE_CODE_CALLBACK_STATUS_CONTINUE,
+    EFI_PXE_BASE_CODE_CALLBACK_STATUS_ABORT,
+    EFI_PXE_BASE_CODE_CALLBACK_STATUS_LAST
+} EFI_PXE_BASE_CODE_CALLBACK_STATUS;
+
+typedef
+EFI_PXE_BASE_CODE_CALLBACK_STATUS
+(EFIAPI *EFI_PXE_CALLBACK) (
+    IN struct _EFI_PXE_BASE_CODE_CALLBACK_PROTOCOL  *This,
+    IN EFI_PXE_BASE_CODE_FUNCTION                   Function,
+    IN BOOLEAN                                      Received,
+    IN UINT32                                       PacketLen,
+    IN EFI_PXE_BASE_CODE_PACKET                     *Packet     OPTIONAL
+    );
+
+typedef struct _EFI_PXE_BASE_CODE_CALLBACK_PROTOCOL {
+    UINT64                      Revision;
+    EFI_PXE_CALLBACK            Callback;
+} EFI_PXE_BASE_CODE_CALLBACK_PROTOCOL;
+
+// Note: Because it conflicted with the EDK2 struct name, the
+// 'EFI_PXE_BASE_CODE_CALLBACK_PROTOCOL' GUID definition, from
+// older versions of gnu-efi, is now obsoleted.
+// Use 'EFI_PXE_BASE_CODE_CALLBACK_PROTOCOL_GUID' instead.
+
+typedef struct _EFI_PXE_BASE_CODE_CALLBACK_PROTOCOL _EFI_PXE_BASE_CODE_CALLBACK;
+typedef EFI_PXE_BASE_CODE_CALLBACK_PROTOCOL EFI_PXE_BASE_CODE_CALLBACK;
+
+#endif /* _EFIPXEBC_H */

--- a/gnu-efi/efiser.h
+++ b/gnu-efi/efiser.h
@@ -1,0 +1,136 @@
+#ifndef _EFI_SER_H
+#define _EFI_SER_H
+
+/*++
+
+Copyright (c) 1998  Intel Corporation
+
+Module Name:
+
+    efiser.h
+
+Abstract:
+
+    EFI serial protocol
+
+Revision History
+
+--*/
+
+//
+// Serial protocol
+//
+
+#define EFI_SERIAL_IO_PROTOCOL_GUID \
+    { 0xBB25CF6F, 0xF1D4, 0x11D2, {0x9A, 0x0C, 0x00, 0x90, 0x27, 0x3F, 0xC1, 0xFD} }
+#define SERIAL_IO_PROTOCOL EFI_SERIAL_IO_PROTOCOL_GUID
+
+INTERFACE_DECL(_EFI_SERIAL_IO_PROTOCOL);
+
+typedef enum {
+    DefaultParity,
+    NoParity,
+    EvenParity,
+    OddParity,
+    MarkParity,
+    SpaceParity
+} EFI_PARITY_TYPE;
+
+typedef enum {
+    DefaultStopBits,
+    OneStopBit,         // 1 stop bit
+    OneFiveStopBits,    // 1.5 stop bits
+    TwoStopBits         // 2 stop bits
+} EFI_STOP_BITS_TYPE;
+
+#define EFI_SERIAL_CLEAR_TO_SEND                   0x0010  // RO
+#define EFI_SERIAL_DATA_SET_READY                  0x0020  // RO
+#define EFI_SERIAL_RING_INDICATE                   0x0040  // RO
+#define EFI_SERIAL_CARRIER_DETECT                  0x0080  // RO
+#define EFI_SERIAL_REQUEST_TO_SEND                 0x0002  // WO
+#define EFI_SERIAL_DATA_TERMINAL_READY             0x0001  // WO
+#define EFI_SERIAL_INPUT_BUFFER_EMPTY              0x0100  // RO
+#define EFI_SERIAL_OUTPUT_BUFFER_EMPTY             0x0200  // RO
+#define EFI_SERIAL_HARDWARE_LOOPBACK_ENABLE        0x1000  // RW
+#define EFI_SERIAL_SOFTWARE_LOOPBACK_ENABLE        0x2000  // RW
+#define EFI_SERIAL_HARDWARE_FLOW_CONTROL_ENABLE    0x4000  // RW
+
+typedef
+EFI_STATUS
+(EFIAPI *EFI_SERIAL_RESET) (
+    IN struct _EFI_SERIAL_IO_PROTOCOL  *This
+    );
+
+typedef
+EFI_STATUS
+(EFIAPI *EFI_SERIAL_SET_ATTRIBUTES) (
+    IN struct _EFI_SERIAL_IO_PROTOCOL  *This,
+    IN UINT64                          BaudRate,
+    IN UINT32                          ReceiveFifoDepth,
+    IN UINT32                          Timeout,
+    IN EFI_PARITY_TYPE                 Parity,
+    IN UINT8                           DataBits,
+    IN EFI_STOP_BITS_TYPE              StopBits
+    );
+
+typedef
+EFI_STATUS
+(EFIAPI *EFI_SERIAL_SET_CONTROL_BITS) (
+    IN struct _EFI_SERIAL_IO_PROTOCOL  *This,
+    IN UINT32                          Control
+    );
+
+typedef
+EFI_STATUS
+(EFIAPI *EFI_SERIAL_GET_CONTROL_BITS) (
+    IN struct _EFI_SERIAL_IO_PROTOCOL  *This,
+    OUT UINT32                         *Control
+    );
+
+typedef
+EFI_STATUS
+(EFIAPI *EFI_SERIAL_WRITE) (
+    IN struct _EFI_SERIAL_IO_PROTOCOL  *This,
+    IN OUT UINTN                       *BufferSize,
+    IN VOID                            *Buffer
+    );
+
+typedef
+EFI_STATUS
+(EFIAPI *EFI_SERIAL_READ) (
+    IN struct _EFI_SERIAL_IO_PROTOCOL  *This,
+    IN OUT UINTN                       *BufferSize,
+    OUT VOID                           *Buffer
+    );
+
+typedef struct {
+    UINT32                  ControlMask;
+
+    // current Attributes
+    UINT32                  Timeout;
+    UINT64                  BaudRate;
+    UINT32                  ReceiveFifoDepth;
+    UINT32                  DataBits;
+    UINT32                  Parity;
+    UINT32                  StopBits;
+} SERIAL_IO_MODE;
+
+#define SERIAL_IO_INTERFACE_REVISION    0x00010000
+
+typedef struct _EFI_SERIAL_IO_PROTOCOL {
+    UINT32                       Revision;
+    EFI_SERIAL_RESET             Reset;
+    EFI_SERIAL_SET_ATTRIBUTES    SetAttributes;
+    EFI_SERIAL_SET_CONTROL_BITS  SetControl;
+    EFI_SERIAL_GET_CONTROL_BITS  GetControl;
+    EFI_SERIAL_WRITE             Write;
+    EFI_SERIAL_READ              Read;
+
+    SERIAL_IO_MODE               *Mode;
+} EFI_SERIAL_IO_PROTOCOL;
+
+typedef struct _EFI_SERIAL_IO_PROTOCOL _SERIAL_IO_INTERFACE;
+typedef EFI_SERIAL_IO_PROTOCOL SERIAL_IO_INTERFACE;
+
+#endif
+

--- a/gnu-efi/efishell.h
+++ b/gnu-efi/efishell.h
@@ -1,0 +1,449 @@
+/**
+  EFI Shell protocol as defined in the UEFI Shell Specification 2.2.
+
+  (C) Copyright 2014 Hewlett-Packard Development Company, L.P.<BR>
+  Copyright (c) 2006 - 2018, Intel Corporation. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+  This file is based on MdePkg/Include/Protocol/Shell.h from EDK2
+  Ported to gnu-efi by Jiaqing Zhao <jiaqing.zhao@intel.com>
+**/
+
+#ifndef _EFI_SHELL_H
+#define _EFI_SHELL_H
+
+#include "efilink.h"
+
+#define EFI_SHELL_PROTOCOL_GUID \
+    { 0x6302d008, 0x7f9b, 0x4f30, { 0x87, 0xac, 0x60, 0xc9, 0xfe, 0xf5, 0xda, 0x4e } }
+
+INTERFACE_DECL(_EFI_SHELL_PROTOCOL);
+
+typedef enum {
+    SHELL_SUCCESS              = 0,
+    SHELL_LOAD_ERROR           = 1,
+    SHELL_INVALID_PARAMETER    = 2,
+    SHELL_UNSUPPORTED          = 3,
+    SHELL_BAD_BUFFER_SIZE      = 4,
+    SHELL_BUFFER_TOO_SMALL     = 5,
+    SHELL_NOT_READY            = 6,
+    SHELL_DEVICE_ERROR         = 7,
+    SHELL_WRITE_PROTECTED      = 8,
+    SHELL_OUT_OF_RESOURCES     = 9,
+    SHELL_VOLUME_CORRUPTED     = 10,
+    SHELL_VOLUME_FULL          = 11,
+    SHELL_NO_MEDIA             = 12,
+    SHELL_MEDIA_CHANGED        = 13,
+    SHELL_NOT_FOUND            = 14,
+    SHELL_ACCESS_DENIED        = 15,
+    SHELL_TIMEOUT              = 18,
+    SHELL_NOT_STARTED          = 19,
+    SHELL_ALREADY_STARTED      = 20,
+    SHELL_ABORTED              = 21,
+    SHELL_INCOMPATIBLE_VERSION = 25,
+    SHELL_SECURITY_VIOLATION   = 26,
+    SHELL_NOT_EQUAL            = 27
+} SHELL_STATUS;
+
+typedef VOID *SHELL_FILE_HANDLE;
+
+typedef struct {
+    LIST_ENTRY    Link;
+    EFI_STATUS        Status;
+    CONST CHAR16      *FullName;
+    CONST CHAR16      *FileName;
+    SHELL_FILE_HANDLE Handle;
+    EFI_FILE_INFO     *Info;
+} EFI_SHELL_FILE_INFO;
+
+typedef
+BOOLEAN
+(EFIAPI *EFI_SHELL_BATCH_IS_ACTIVE) (
+    VOID
+    );
+
+typedef
+EFI_STATUS
+(EFIAPI *EFI_SHELL_CLOSE_FILE) (
+    IN SHELL_FILE_HANDLE FileHandle
+    );
+
+typedef
+EFI_STATUS
+(EFIAPI *EFI_SHELL_CREATE_FILE) (
+    IN CONST CHAR16       *FileName,
+    IN UINT64             FileAttribs,
+    OUT SHELL_FILE_HANDLE *FileHandle
+    );
+
+typedef
+EFI_STATUS
+(EFIAPI *EFI_SHELL_DELETE_FILE) (
+    IN SHELL_FILE_HANDLE FileHandle
+    );
+
+typedef
+EFI_STATUS
+(EFIAPI *EFI_SHELL_DELETE_FILE_BY_NAME) (
+    IN CONST CHAR16 *FileName
+    );
+
+typedef
+VOID
+(EFIAPI *EFI_SHELL_DISABLE_PAGE_BREAK) (
+    VOID
+    );
+
+typedef
+VOID
+(EFIAPI *EFI_SHELL_ENABLE_PAGE_BREAK) (
+    VOID
+    );
+
+typedef
+EFI_STATUS
+(EFIAPI *EFI_SHELL_EXECUTE) (
+    IN EFI_HANDLE  *ParentImageHandle,
+    IN CHAR16      *CommandLine OPTIONAL,
+    IN CHAR16      **Environment OPTIONAL,
+    OUT EFI_STATUS *StatusCode OPTIONAL
+    );
+
+typedef
+EFI_STATUS
+(EFIAPI *EFI_SHELL_FIND_FILES) (
+    IN CONST CHAR16         *FilePattern,
+    OUT EFI_SHELL_FILE_INFO **FileList
+    );
+
+typedef
+EFI_STATUS
+(EFIAPI *EFI_SHELL_FIND_FILES_IN_DIR) (
+    IN SHELL_FILE_HANDLE    FileDirHandle,
+    OUT EFI_SHELL_FILE_INFO **FileList
+    );
+
+typedef
+EFI_STATUS
+(EFIAPI *EFI_SHELL_FLUSH_FILE) (
+    IN SHELL_FILE_HANDLE FileHandle
+    );
+
+typedef
+EFI_STATUS
+(EFIAPI *EFI_SHELL_FREE_FILE_LIST) (
+    IN EFI_SHELL_FILE_INFO **FileList
+    );
+
+typedef
+CONST CHAR16 *
+(EFIAPI *EFI_SHELL_GET_ALIAS) (
+  IN  CONST CHAR16 *Alias,
+  OUT BOOLEAN      *Volatile OPTIONAL
+  );
+
+typedef
+CONST CHAR16 *
+(EFIAPI *EFI_SHELL_GET_CUR_DIR) (
+  IN CONST CHAR16 *FileSystemMapping OPTIONAL
+  );
+
+typedef UINT32 EFI_SHELL_DEVICE_NAME_FLAGS;
+#define EFI_DEVICE_NAME_USE_COMPONENT_NAME 0x00000001
+#define EFI_DEVICE_NAME_USE_DEVICE_PATH    0x00000002
+
+typedef
+EFI_STATUS
+(EFIAPI *EFI_SHELL_GET_DEVICE_NAME) (
+    IN EFI_HANDLE                   DeviceHandle,
+    IN EFI_SHELL_DEVICE_NAME_FLAGS  Flags,
+    IN CHAR8                        *Language,
+    OUT CHAR16                      **BestDeviceName
+    );
+
+typedef
+CONST EFI_DEVICE_PATH_PROTOCOL *
+(EFIAPI *EFI_SHELL_GET_DEVICE_PATH_FROM_MAP) (
+    IN CONST CHAR16 *Mapping
+    );
+
+typedef
+EFI_DEVICE_PATH_PROTOCOL *
+(EFIAPI *EFI_SHELL_GET_DEVICE_PATH_FROM_FILE_PATH) (
+    IN CONST CHAR16 *Path
+    );
+
+typedef
+CONST CHAR16 *
+(EFIAPI *EFI_SHELL_GET_ENV) (
+    IN CONST CHAR16 *Name
+    );
+
+typedef
+CONST CHAR16 *
+(EFIAPI *EFI_SHELL_GET_ENV_EX) (
+    IN CONST CHAR16 *Name,
+    OUT UINT32      *Attributes OPTIONAL
+    );
+
+typedef
+EFI_FILE_INFO *
+(EFIAPI *EFI_SHELL_GET_FILE_INFO) (
+    IN SHELL_FILE_HANDLE FileHandle
+    );
+
+typedef
+CHAR16 *
+(EFIAPI *EFI_SHELL_GET_FILE_PATH_FROM_DEVICE_PATH) (
+    IN CONST EFI_DEVICE_PATH_PROTOCOL *Path
+    );
+
+typedef
+EFI_STATUS
+(EFIAPI *EFI_SHELL_GET_FILE_POSITION) (
+    IN SHELL_FILE_HANDLE FileHandle,
+    OUT UINT64           *Position
+    );
+
+typedef
+EFI_STATUS
+(EFIAPI *EFI_SHELL_GET_FILE_SIZE) (
+    IN SHELL_FILE_HANDLE FileHandle,
+    OUT UINT64           *Size
+    );
+
+typedef
+EFI_STATUS
+(EFIAPI *EFI_SHELL_GET_GUID_FROM_NAME) (
+    IN CONST CHAR16 *GuidName,
+    OUT EFI_GUID    *Guid
+    );
+
+typedef
+EFI_STATUS
+(EFIAPI *EFI_SHELL_GET_GUID_NAME)(
+    IN CONST EFI_GUID *Guid,
+    OUT CONST CHAR16  **GuidName
+    );
+
+typedef
+EFI_STATUS
+(EFIAPI *EFI_SHELL_GET_HELP_TEXT) (
+    IN CONST CHAR16 *Command,
+    IN CONST CHAR16 *Sections,
+    OUT CHAR16      **HelpText
+    );
+
+typedef
+CONST CHAR16 *
+(EFIAPI *EFI_SHELL_GET_MAP_FROM_DEVICE_PATH) (
+    IN OUT EFI_DEVICE_PATH_PROTOCOL **DevicePath
+    );
+
+typedef
+BOOLEAN
+(EFIAPI *EFI_SHELL_GET_PAGE_BREAK) (
+    VOID
+    );
+
+typedef
+BOOLEAN
+(EFIAPI *EFI_SHELL_IS_ROOT_SHELL) (
+    VOID
+    );
+
+typedef
+EFI_STATUS
+(EFIAPI *EFI_SHELL_OPEN_FILE_BY_NAME) (
+    IN CONST CHAR16       *FileName,
+    OUT SHELL_FILE_HANDLE *FileHandle,
+    IN UINT64             OpenMode
+    );
+
+typedef
+EFI_STATUS
+(EFIAPI *EFI_SHELL_OPEN_FILE_LIST) (
+    IN CHAR16                  *Path,
+    IN UINT64                  OpenMode,
+    IN OUT EFI_SHELL_FILE_INFO **FileList
+    );
+
+typedef
+EFI_STATUS
+(EFIAPI *EFI_SHELL_OPEN_ROOT) (
+    IN EFI_DEVICE_PATH_PROTOCOL *DevicePath,
+    OUT SHELL_FILE_HANDLE       *FileHandle
+    );
+
+typedef
+EFI_STATUS
+(EFIAPI *EFI_SHELL_OPEN_ROOT_BY_HANDLE) (
+    IN EFI_HANDLE         DeviceHandle,
+    OUT SHELL_FILE_HANDLE *FileHandle
+    );
+
+typedef
+EFI_STATUS
+(EFIAPI *EFI_SHELL_READ_FILE) (
+    IN SHELL_FILE_HANDLE FileHandle,
+    IN OUT UINTN         *ReadSize,
+    IN OUT VOID          *Buffer
+    );
+
+typedef
+EFI_STATUS
+(EFIAPI *EFI_SHELL_REGISTER_GUID_NAME) (
+    IN CONST EFI_GUID *Guid,
+    IN CONST CHAR16   *GuidName
+    );
+
+typedef
+EFI_STATUS
+(EFIAPI *EFI_SHELL_REMOVE_DUP_IN_FILE_LIST) (
+    IN EFI_SHELL_FILE_INFO **FileList
+    );
+
+typedef
+EFI_STATUS
+(EFIAPI *EFI_SHELL_SET_ALIAS) (
+    IN CONST CHAR16 *Command,
+    IN CONST CHAR16 *Alias,
+    IN BOOLEAN      Replace,
+    IN BOOLEAN      Volatile
+    );
+
+typedef
+EFI_STATUS
+(EFIAPI *EFI_SHELL_SET_CUR_DIR) (
+    IN CONST CHAR16 *FileSystem OPTIONAL,
+    IN CONST CHAR16 *Dir
+    );
+
+typedef
+EFI_STATUS
+(EFIAPI *EFI_SHELL_SET_ENV) (
+    IN CONST CHAR16 *Name,
+    IN CONST CHAR16 *Value,
+    IN BOOLEAN      Volatile
+    );
+
+typedef
+EFI_STATUS
+(EFIAPI *EFI_SHELL_SET_FILE_INFO) (
+    IN SHELL_FILE_HANDLE   FileHandle,
+    IN CONST EFI_FILE_INFO *FileInfo
+    );
+
+typedef
+EFI_STATUS
+(EFIAPI *EFI_SHELL_SET_FILE_POSITION) (
+    IN SHELL_FILE_HANDLE FileHandle,
+    IN UINT64            Position
+    );
+
+typedef
+EFI_STATUS
+(EFIAPI *EFI_SHELL_SET_MAP) (
+    IN CONST EFI_DEVICE_PATH_PROTOCOL *DevicePath,
+    IN CONST CHAR16                   *Mapping
+    );
+
+typedef
+EFI_STATUS
+(EFIAPI *EFI_SHELL_WRITE_FILE) (
+    IN SHELL_FILE_HANDLE FileHandle,
+    IN OUT UINTN         *BufferSize,
+    IN VOID              *Buffer
+    );
+
+typedef struct _EFI_SHELL_PROTOCOL {
+    EFI_SHELL_EXECUTE                         Execute;
+    EFI_SHELL_GET_ENV                         GetEnv;
+    EFI_SHELL_SET_ENV                         SetEnv;
+    EFI_SHELL_GET_ALIAS                       GetAlias;
+    EFI_SHELL_SET_ALIAS                       SetAlias;
+    EFI_SHELL_GET_HELP_TEXT                   GetHelpText;
+    EFI_SHELL_GET_DEVICE_PATH_FROM_MAP        GetDevicePathFromMap;
+    EFI_SHELL_GET_MAP_FROM_DEVICE_PATH        GetMapFromDevicePath;
+    EFI_SHELL_GET_DEVICE_PATH_FROM_FILE_PATH  GetDevicePathFromFilePath;
+    EFI_SHELL_GET_FILE_PATH_FROM_DEVICE_PATH  GetFilePathFromDevicePath;
+    EFI_SHELL_SET_MAP                         SetMap;
+    EFI_SHELL_GET_CUR_DIR                     GetCurDir;
+    EFI_SHELL_SET_CUR_DIR                     SetCurDir;
+    EFI_SHELL_OPEN_FILE_LIST                  OpenFileList;
+    EFI_SHELL_FREE_FILE_LIST                  FreeFileList;
+    EFI_SHELL_REMOVE_DUP_IN_FILE_LIST         RemoveDupInFileList;
+    EFI_SHELL_BATCH_IS_ACTIVE                 BatchIsActive;
+    EFI_SHELL_IS_ROOT_SHELL                   IsRootShell;
+    EFI_SHELL_ENABLE_PAGE_BREAK               EnablePageBreak;
+    EFI_SHELL_DISABLE_PAGE_BREAK              DisablePageBreak;
+    EFI_SHELL_GET_PAGE_BREAK                  GetPageBreak;
+    EFI_SHELL_GET_DEVICE_NAME                 GetDeviceName;
+    EFI_SHELL_GET_FILE_INFO                   GetFileInfo;
+    EFI_SHELL_SET_FILE_INFO                   SetFileInfo;
+    EFI_SHELL_OPEN_FILE_BY_NAME               OpenFileByName;
+    EFI_SHELL_CLOSE_FILE                      CloseFile;
+    EFI_SHELL_CREATE_FILE                     CreateFile;
+    EFI_SHELL_READ_FILE                       ReadFile;
+    EFI_SHELL_WRITE_FILE                      WriteFile;
+    EFI_SHELL_DELETE_FILE                     DeleteFile;
+    EFI_SHELL_DELETE_FILE_BY_NAME             DeleteFileByName;
+    EFI_SHELL_GET_FILE_POSITION               GetFilePosition;
+    EFI_SHELL_SET_FILE_POSITION               SetFilePosition;
+    EFI_SHELL_FLUSH_FILE                      FlushFile;
+    EFI_SHELL_FIND_FILES                      FindFiles;
+    EFI_SHELL_FIND_FILES_IN_DIR               FindFilesInDir;
+    EFI_SHELL_GET_FILE_SIZE                   GetFileSize;
+    EFI_SHELL_OPEN_ROOT                       OpenRoot;
+    EFI_SHELL_OPEN_ROOT_BY_HANDLE             OpenRootByHandle;
+    EFI_EVENT                                 ExecutionBreak;
+    UINT32                                    MajorVersion;
+    UINT32                                    MinorVersion;
+    // Added for Shell 2.1
+    EFI_SHELL_REGISTER_GUID_NAME              RegisterGuidName;
+    EFI_SHELL_GET_GUID_NAME                   GetGuidName;
+    EFI_SHELL_GET_GUID_FROM_NAME              GetGuidFromName;
+    EFI_SHELL_GET_ENV_EX                      GetEnvEx;
+} EFI_SHELL_PROTOCOL;
+
+#define EFI_SHELL_PARAMETERS_PROTOCOL_GUID \
+    { 0x752f3136, 0x4e16, 0x4fdc, { 0xa2, 0x2a, 0xe5, 0xf4, 0x68, 0x12, 0xf4, 0xca } }
+
+INTERFACE_DECL(_EFI_SHELL_PARAMETERS_PROTOCOL);
+
+typedef struct _EFI_SHELL_PARAMETERS_PROTOCOL {
+    CHAR16            **Argv;
+    UINTN             Argc;
+    SHELL_FILE_HANDLE StdIn;
+    SHELL_FILE_HANDLE StdOut;
+    SHELL_FILE_HANDLE StdErr;
+} EFI_SHELL_PARAMETERS_PROTOCOL;
+
+#define EFI_SHELL_DYNAMIC_COMMAND_PROTOCOL_GUID \
+    { 0x3c7200e9, 0x005f, 0x4ea4, { 0x87, 0xde, 0xa3, 0xdf, 0xac, 0x8a, 0x27, 0xc3 } }
+
+INTERFACE_DECL(_EFI_SHELL_DYNAMIC_COMMAND_PROTOCOL);
+
+typedef
+SHELL_STATUS
+(EFIAPI *SHELL_COMMAND_HANDLER)(
+    IN struct _EFI_SHELL_DYNAMIC_COMMAND_PROTOCOL *This,
+    IN EFI_SYSTEM_TABLE                           *SystemTable,
+    IN EFI_SHELL_PARAMETERS_PROTOCOL              *ShellParameters,
+    IN EFI_SHELL_PROTOCOL                         *Shell
+    );
+
+typedef
+CHAR16*
+(EFIAPI *SHELL_COMMAND_GETHELP)(
+    IN struct _EFI_SHELL_DYNAMIC_COMMAND_PROTOCOL *This,
+    IN CONST CHAR8                                *Language
+    );
+
+typedef struct _EFI_SHELL_DYNAMIC_COMMAND_PROTOCOL {
+    CONST CHAR16          *CommandName;
+    SHELL_COMMAND_HANDLER Handler;
+    SHELL_COMMAND_GETHELP GetHelp;
+} EFI_SHELL_DYNAMIC_COMMAND_PROTOCOL;
+
+#endif

--- a/gnu-efi/efitcp.h
+++ b/gnu-efi/efitcp.h
@@ -1,0 +1,391 @@
+#ifndef _EFI_TCP_H
+#define _EFI_TCP_H
+
+/*++
+Copyright (c) 2013  Intel Corporation
+
+--*/
+
+#define EFI_TCP4_SERVICE_BINDING_PROTOCOL \
+    { 0x00720665, 0x67eb, 0x4a99, {0xba, 0xf7, 0xd3, 0xc3, 0x3a, 0x1c,0x7c, 0xc9}}
+
+#define EFI_TCP4_PROTOCOL \
+    { 0x65530bc7, 0xa359, 0x410f, {0xb0, 0x10, 0x5a, 0xad, 0xc7, 0xec, 0x2b, 0x62}}
+
+#define EFI_TCP6_SERVICE_BINDING_PROTOCOL \
+    { 0xec20eb79, 0x6c1a, 0x4664, {0x9a, 0xd, 0xd2, 0xe4, 0xcc, 0x16, 0xd6, 0x64}}
+
+#define EFI_TCP6_PROTOCOL \
+    { 0x46e44855, 0xbd60, 0x4ab7, {0xab, 0xd, 0xa6, 0x79, 0xb9, 0x44, 0x7d, 0x77}}
+
+INTERFACE_DECL(_EFI_TCP4);
+INTERFACE_DECL(_EFI_TCP6);
+
+typedef struct {
+    BOOLEAN            UseDefaultAddress;
+    EFI_IPv4_ADDRESS   StationAddress;
+    EFI_IPv4_ADDRESS   SubnetMask;
+    UINT16             StationPort;
+    EFI_IPv4_ADDRESS   RemoteAddress;
+    UINT16             RemotePort;
+    BOOLEAN            ActiveFlag;
+} EFI_TCP4_ACCESS_POINT;
+
+typedef struct {
+    UINT32             ReceiveBufferSize;
+    UINT32             SendBufferSize;
+    UINT32             MaxSynBackLog;
+    UINT32             ConnectionTimeout;
+    UINT32             DataRetries;
+    UINT32             FinTimeout;
+    UINT32             TimeWaitTimeout;
+    UINT32             KeepAliveProbes;
+    UINT32             KeepAliveTime;
+    UINT32             KeepAliveInterval;
+    BOOLEAN            EnableNagle;
+    BOOLEAN            EnableTimeStamp;
+    BOOLEAN            EnableWindowScaling;
+    BOOLEAN            EnableSelectiveAck;
+    BOOLEAN            EnablePAthMtuDiscovery;
+} EFI_TCP4_OPTION;
+
+typedef struct {
+    // Receiving Filters
+    // I/O parameters
+    UINT8                 TypeOfService;
+    UINT8                 TimeToLive;
+
+    // Access Point
+    EFI_TCP4_ACCESS_POINT AccessPoint;
+
+    // TCP Control Options
+    EFI_TCP4_OPTION       *ControlOption;
+} EFI_TCP4_CONFIG_DATA;
+
+typedef enum {
+    Tcp4StateClosed      = 0,
+    Tcp4StateListen      = 1,
+    Tcp4StateSynSent     = 2,
+    Tcp4StateSynReceived = 3,
+    Tcp4StateEstablished = 4,
+    Tcp4StateFinWait1    = 5,
+    Tcp4StateFinWait2    = 6,
+    Tcp4StateClosing     = 7,
+    Tcp4StateTimeWait    = 8,
+    Tcp4StateCloseWait   = 9,
+    Tcp4StateLastAck     = 10
+} EFI_TCP4_CONNECTION_STATE;
+
+typedef
+EFI_STATUS
+(EFIAPI *EFI_TCP4_GET_MODE_DATA) (
+    IN struct _EFI_TCP4                 *This,
+    OUT EFI_TCP4_CONNECTION_STATE       *Tcp4State      OPTIONAL,
+    OUT EFI_TCP4_CONFIG_DATA            *Tcp4ConfigData OPTIONAL,
+    OUT EFI_IP4_MODE_DATA               *Ip4ModeData    OPTIONAL,
+    OUT EFI_MANAGED_NETWORK_CONFIG_DATA *MnpConfigData  OPTIONAL,
+    OUT EFI_SIMPLE_NETWORK_MODE         *SnpModeData    OPTIONAL
+    );
+
+typedef
+EFI_STATUS
+(EFIAPI *EFI_TCP4_CONFIGURE) (
+    IN struct _EFI_TCP4     *This,
+    IN EFI_TCP4_CONFIG_DATA *TcpConfigData OPTIONAL
+    );
+
+typedef
+EFI_STATUS
+(EFIAPI *EFI_TCP4_ROUTES) (
+    IN struct _EFI_TCP4 *This,
+    IN BOOLEAN          DeleteRoute,
+    IN EFI_IPv4_ADDRESS *SubnetAddress,
+    IN EFI_IPv4_ADDRESS *SubnetMask,
+    IN EFI_IPv4_ADDRESS *GatewayAddress
+);
+
+typedef struct {
+    EFI_EVENT  Event;
+    EFI_STATUS Status;
+} EFI_TCP4_COMPLETION_TOKEN;
+
+typedef struct {
+    EFI_TCP4_COMPLETION_TOKEN CompletionToken;
+} EFI_TCP4_CONNECTION_TOKEN;
+
+typedef
+EFI_STATUS
+(EFIAPI *EFI_TCP4_CONNECT) (
+    IN struct _EFI_TCP4          *This,
+    IN EFI_TCP4_CONNECTION_TOKEN *ConnectionToken
+    );
+
+typedef struct {
+    EFI_TCP4_COMPLETION_TOKEN CompletionToken;
+    EFI_HANDLE                NewChildHandle;
+} EFI_TCP4_LISTEN_TOKEN;
+
+typedef
+EFI_STATUS
+(EFIAPI *EFI_TCP4_ACCEPT) (
+    IN struct _EFI_TCP4      *This,
+    IN EFI_TCP4_LISTEN_TOKEN *ListenToken
+    );
+
+#define EFI_CONNECTION_FIN     EFIERR(104)
+#define EFI_CONNECTION_RESET   EFIERR(105)
+#define EFI_CONNECTION_REFUSED EFIERR(106)
+
+typedef struct {
+    UINT32 FragmentLength;
+    VOID   *FragmentBuffer;
+} EFI_TCP4_FRAGMENT_DATA;
+
+typedef struct {
+    BOOLEAN                UrgentFlag;
+    UINT32                 DataLength;
+    UINT32                 FragmentCount;
+    EFI_TCP4_FRAGMENT_DATA FragmentTable[1];
+} EFI_TCP4_RECEIVE_DATA;
+
+typedef struct {
+    BOOLEAN                Push;
+    BOOLEAN                Urgent;
+    UINT32                 DataLength;
+    UINT32                 FragmentCount;
+    EFI_TCP4_FRAGMENT_DATA FragmentTable[1];
+} EFI_TCP4_TRANSMIT_DATA;
+
+typedef struct {
+    EFI_TCP4_COMPLETION_TOKEN  CompletionToken;
+    union {
+	EFI_TCP4_RECEIVE_DATA  *RxData;
+	EFI_TCP4_TRANSMIT_DATA *TxData;
+    }                          Packet;
+} EFI_TCP4_IO_TOKEN;
+
+typedef
+EFI_STATUS
+(EFIAPI *EFI_TCP4_TRANSMIT) (
+    IN struct _EFI_TCP4  *This,
+    IN EFI_TCP4_IO_TOKEN *Token
+    );
+
+typedef
+EFI_STATUS
+(EFIAPI *EFI_TCP4_RECEIVE) (
+    IN struct _EFI_TCP4  *This,
+    IN EFI_TCP4_IO_TOKEN *Token
+    );
+
+typedef struct {
+    EFI_TCP4_COMPLETION_TOKEN CompletionToken;
+    BOOLEAN                   AbortOnClose;
+} EFI_TCP4_CLOSE_TOKEN;
+
+typedef
+EFI_STATUS
+(EFIAPI *EFI_TCP4_CLOSE)(
+    IN struct _EFI_TCP4     *This,
+    IN EFI_TCP4_CLOSE_TOKEN *CloseToken
+    );
+
+typedef
+EFI_STATUS
+(EFIAPI *EFI_TCP4_CANCEL)(
+    IN struct _EFI_TCP4 *This,
+    IN EFI_TCP4_COMPLETION_TOKEN *Token OPTIONAL
+);
+
+typedef
+EFI_STATUS
+(EFIAPI *EFI_TCP4_POLL) (
+    IN struct _EFI_TCP4 *This
+    );
+
+typedef struct _EFI_TCP4 {
+    EFI_TCP4_GET_MODE_DATA GetModeData;
+    EFI_TCP4_CONFIGURE     Configure;
+    EFI_TCP4_ROUTES        Routes;
+    EFI_TCP4_CONNECT       Connect;
+    EFI_TCP4_ACCEPT        Accept;
+    EFI_TCP4_TRANSMIT      Transmit;
+    EFI_TCP4_RECEIVE       Receive;
+    EFI_TCP4_CLOSE         Close;
+    EFI_TCP4_CANCEL        Cancel;
+    EFI_TCP4_POLL          Poll;
+} EFI_TCP4;
+
+typedef enum {
+    Tcp6StateClosed      = 0,
+    Tcp6StateListen      = 1,
+    Tcp6StateSynSent     = 2,
+    Tcp6StateSynReceived = 3,
+    Tcp6StateEstablished = 4,
+    Tcp6StateFinWait1    = 5,
+    Tcp6StateFinWait2    = 6,
+    Tcp6StateClosing     = 7,
+    Tcp6StateTimeWait    = 8,
+    Tcp6StateCloseWait   = 9,
+    Tcp6StateLastAck     = 10
+} EFI_TCP6_CONNECTION_STATE;
+
+typedef struct {
+    EFI_IPv6_ADDRESS StationAddress;
+    UINT16           StationPort;
+    EFI_IPv6_ADDRESS RemoteAddress;
+    UINT16           RemotePort;
+    BOOLEAN          ActiveFlag;
+} EFI_TCP6_ACCESS_POINT;
+
+typedef struct {
+    UINT32             ReceiveBufferSize;
+    UINT32             SendBufferSize;
+    UINT32             MaxSynBackLog;
+    UINT32             ConnectionTimeout;
+    UINT32             DataRetries;
+    UINT32             FinTimeout;
+    UINT32             TimeWaitTimeout;
+    UINT32             KeepAliveProbes;
+    UINT32             KeepAliveTime;
+    UINT32             KeepAliveInterval;
+    BOOLEAN            EnableNagle;
+    BOOLEAN            EnableTimeStamp;
+    BOOLEAN            EnableWindbowScaling;
+    BOOLEAN            EnableSelectiveAck;
+    BOOLEAN            EnablePathMtuDiscovery;
+} EFI_TCP6_OPTION;
+
+typedef struct {
+    UINT8                 TrafficClass;
+    UINT8                 HopLimit;
+    EFI_TCP6_ACCESS_POINT AccessPoint;
+    EFI_TCP6_OPTION       *ControlOption;
+} EFI_TCP6_CONFIG_DATA;
+
+typedef
+EFI_STATUS
+(EFIAPI *EFI_TCP6_GET_MODE_DATA) (
+    IN struct _EFI_TCP6                 *This,
+    OUT EFI_TCP6_CONNECTION_STATE       *Tcp6State      OPTIONAL,
+    OUT EFI_TCP6_CONFIG_DATA            *Tcp6ConfigData OPTIONAL,
+    OUT EFI_IP6_MODE_DATA               *Ip6ModeData    OPTIONAL,
+    OUT EFI_MANAGED_NETWORK_CONFIG_DATA *MnpConfigData  OPTIONAL,
+    OUT EFI_SIMPLE_NETWORK_MODE         *SnpModeData    OPTIONAL
+    );
+
+typedef
+EFI_STATUS
+(EFIAPI *EFI_TCP6_CONFIGURE) (
+    IN struct _EFI_TCP6     *This,
+    IN EFI_TCP6_CONFIG_DATA *Tcp6ConfigData OPTIONAL
+    );
+
+typedef struct {
+    EFI_EVENT  Event;
+    EFI_STATUS Status;
+} EFI_TCP6_COMPLETION_TOKEN;
+
+typedef struct {
+    EFI_TCP6_COMPLETION_TOKEN CompletionToken;
+} EFI_TCP6_CONNECTION_TOKEN;
+
+typedef
+EFI_STATUS
+(EFIAPI *EFI_TCP6_CONNECT) (
+    IN struct _EFI_TCP6          *This,
+    IN EFI_TCP6_CONNECTION_TOKEN *ConnectionToken
+    );
+
+typedef struct {
+    EFI_TCP6_COMPLETION_TOKEN CompletionToken;
+    EFI_HANDLE                NewChildHandle;
+} EFI_TCP6_LISTEN_TOKEN;
+
+typedef
+EFI_STATUS
+(EFIAPI *EFI_TCP6_ACCEPT) (
+    IN struct _EFI_TCP6      *This,
+    IN EFI_TCP6_LISTEN_TOKEN *ListenToken
+    );
+
+typedef struct {
+    UINT32 FragmentLength;
+    VOID   *FragmentBuffer;
+} EFI_TCP6_FRAGMENT_DATA;
+
+typedef struct {
+    BOOLEAN                UrgentFlag;
+    UINT32                 DataLength;
+    UINT32                 FragmentCount;
+    EFI_TCP6_FRAGMENT_DATA FragmentTable[1];
+} EFI_TCP6_RECEIVE_DATA;
+
+typedef struct {
+    BOOLEAN                Push;
+    BOOLEAN                Urgent;
+    UINT32                 DataLength;
+    UINT32                 FragmentCount;
+    EFI_TCP6_FRAGMENT_DATA FragmentTable[1];
+} EFI_TCP6_TRANSMIT_DATA;
+
+typedef struct {
+    EFI_TCP6_COMPLETION_TOKEN  CompletionToken;
+    union {
+	EFI_TCP6_RECEIVE_DATA  *RxData;
+	EFI_TCP6_TRANSMIT_DATA *TxData;
+    }                          Packet;
+} EFI_TCP6_IO_TOKEN;
+
+typedef
+EFI_STATUS
+(EFIAPI *EFI_TCP6_TRANSMIT) (
+    IN struct _EFI_TCP6  *This,
+    IN EFI_TCP6_IO_TOKEN *Token
+    );
+
+typedef
+EFI_STATUS
+(EFIAPI *EFI_TCP6_RECEIVE) (
+    IN struct _EFI_TCP6  *This,
+    IN EFI_TCP6_IO_TOKEN *Token
+    );
+
+typedef struct {
+    EFI_TCP6_COMPLETION_TOKEN CompletionToken;
+    BOOLEAN                   AbortOnClose;
+} EFI_TCP6_CLOSE_TOKEN;
+
+typedef
+EFI_STATUS
+(EFIAPI *EFI_TCP6_CLOSE)(
+    IN struct _EFI_TCP6     *This,
+    IN EFI_TCP6_CLOSE_TOKEN *CloseToken
+    );
+
+typedef
+EFI_STATUS
+(EFIAPI *EFI_TCP6_CANCEL)(
+    IN struct _EFI_TCP6          *This,
+    IN EFI_TCP6_COMPLETION_TOKEN *Token OPTIONAL
+    );
+
+typedef
+EFI_STATUS
+(EFIAPI *EFI_TCP6_POLL) (
+    IN struct _EFI_TCP6 *This
+    );
+
+typedef struct _EFI_TCP6 {
+    EFI_TCP6_GET_MODE_DATA GetModeData;
+    EFI_TCP6_CONFIGURE     Configure;
+    EFI_TCP6_CONNECT       Connect;
+    EFI_TCP6_ACCEPT        Accept;
+    EFI_TCP6_TRANSMIT      Transmit;
+    EFI_TCP6_RECEIVE       Receive;
+    EFI_TCP6_CLOSE         Close;
+    EFI_TCP6_CANCEL        Cancel;
+    EFI_TCP6_POLL          Poll;
+} EFI_TCP6;
+
+#endif /* _EFI_TCP_H */

--- a/gnu-efi/efiudp.h
+++ b/gnu-efi/efiudp.h
@@ -1,0 +1,272 @@
+#ifndef _EFI_UDP_H
+#define _EFI_UDP_H
+
+
+/*++
+Copyright (c) 2013  Intel Corporation
+
+--*/
+
+#define EFI_UDP4_SERVICE_BINDING_PROTOCOL \
+    { 0x83f01464, 0x99bd, 0x45e5, {0xb3, 0x83, 0xaf, 0x63, 0x05, 0xd8, 0xe9, 0xe6} }
+
+#define EFI_UDP4_PROTOCOL \
+    { 0x3ad9df29, 0x4501, 0x478d, {0xb1, 0xf8, 0x7f, 0x7f, 0xe7, 0x0e, 0x50, 0xf3} }
+
+#define EFI_UDP6_SERVICE_BINDING_PROTOCOL \
+    { 0x66ed4721, 0x3c98, 0x4d3e, {0x81, 0xe3, 0xd0, 0x3d, 0xd3, 0x9a, 0x72, 0x54} }
+
+#define EFI_UDP6_PROTOCOL \
+    { 0x4f948815, 0xb4b9, 0x43cb, {0x8a, 0x33, 0x90, 0xe0, 0x60, 0xb3,0x49, 0x55} }
+
+INTERFACE_DECL(_EFI_UDP4);
+INTERFACE_DECL(_EFI_UDP6);
+
+typedef struct {
+    BOOLEAN          AcceptBroadcast;
+    BOOLEAN          AcceptPromiscuous;
+    BOOLEAN          AcceptAnyPort;
+    BOOLEAN          AllowDuplicatePort;
+    UINT8            TypeOfService;
+    UINT8            TimeToLive;
+    BOOLEAN          DoNotFragment;
+    UINT32           ReceiveTimeout;
+    UINT32           TransmitTimeout;
+    BOOLEAN          UseDefaultAddress;
+    EFI_IPv4_ADDRESS StationAddress;
+    EFI_IPv4_ADDRESS SubnetMask;
+    UINT16           StationPort;
+    EFI_IPv4_ADDRESS RemoteAddress;
+    UINT16           RemotePort;
+} EFI_UDP4_CONFIG_DATA;
+
+typedef
+EFI_STATUS
+(EFIAPI *EFI_UDP4_GET_MODE_DATA) (
+    IN struct _EFI_UDP4                 *This,
+    OUT EFI_UDP4_CONFIG_DATA            *Udp4ConfigData OPTIONAL,
+    OUT EFI_IP4_MODE_DATA               *Ip4ModeData    OPTIONAL,
+    OUT EFI_MANAGED_NETWORK_CONFIG_DATA *MnpConfigData  OPTIONAL,
+    OUT EFI_SIMPLE_NETWORK_MODE         *SnpModeData    OPTIONAL
+    );
+
+typedef
+EFI_STATUS
+(EFIAPI *EFI_UDP4_CONFIGURE) (
+    IN struct _EFI_UDP4     *This,
+    IN EFI_UDP4_CONFIG_DATA *UdpConfigData OPTIONAL
+    );
+
+typedef
+EFI_STATUS
+(EFIAPI *EFI_UDP4_GROUPS) (
+    IN struct _EFI_UDP4 *This,
+    IN BOOLEAN          JoinFlag,
+    IN EFI_IPv4_ADDRESS *MulticastAddress OPTIONAL
+    );
+
+typedef
+EFI_STATUS
+(EFIAPI *EFI_UDP4_ROUTES) (
+    IN struct _EFI_UDP4 *This,
+    IN BOOLEAN          DeleteRoute,
+    IN EFI_IPv4_ADDRESS *SubnetAddress,
+    IN EFI_IPv4_ADDRESS *SubnetMask,
+    IN EFI_IPv4_ADDRESS *GatewayAddress
+    );
+
+#define EFI_NETWORK_UNREACHABLE  EFIERR(100)
+#define EFI_HOST_UNREACHABLE     EFIERR(101)
+#define EFI_PROTOCOL_UNREACHABLE EFIERR(102)
+#define EFI_PORT_UNREACHABLE     EFIERR(103)
+
+typedef struct {
+    EFI_IPv4_ADDRESS SourceAddress;
+    UINT16           SourcePort;
+    EFI_IPv4_ADDRESS DestinationAddress;
+    UINT16           DestinationPort;
+} EFI_UDP4_SESSION_DATA;
+
+typedef struct {
+    UINT32 FragmentLength;
+    VOID   *FragmentBuffer;
+} EFI_UDP4_FRAGMENT_DATA;
+
+typedef struct {
+    EFI_TIME               TimeStamp;
+    EFI_EVENT              RecycleSignal;
+    EFI_UDP4_SESSION_DATA  UdpSession;
+    UINT32                 DataLength;
+    UINT32                 FragmentCount;
+    EFI_UDP4_FRAGMENT_DATA FragmentTable[1];
+} EFI_UDP4_RECEIVE_DATA;
+
+typedef struct {
+    EFI_UDP4_SESSION_DATA  *UdpSessionData;
+    EFI_IPv4_ADDRESS       *GatewayAddress;
+    UINT32                 DataLength;
+    UINT32                 FragmentCount;
+    EFI_UDP4_FRAGMENT_DATA FragmentTable[1];
+} EFI_UDP4_TRANSMIT_DATA;
+
+typedef struct {
+    EFI_EVENT                  Event;
+    EFI_STATUS                 Status;
+    union {
+        EFI_UDP4_RECEIVE_DATA  *RxData;
+	EFI_UDP4_TRANSMIT_DATA *TxData;
+    }                          Packet;
+} EFI_UDP4_COMPLETION_TOKEN;
+
+typedef
+EFI_STATUS
+(EFIAPI *EFI_UDP4_TRANSMIT) (
+    IN struct _EFI_UDP4          *This,
+    IN EFI_UDP4_COMPLETION_TOKEN *Token
+    );
+
+typedef
+EFI_STATUS
+(EFIAPI *EFI_UDP4_RECEIVE) (
+    IN struct _EFI_UDP4          *This,
+    IN EFI_UDP4_COMPLETION_TOKEN *Token
+    );
+
+typedef
+EFI_STATUS
+(EFIAPI *EFI_UDP4_CANCEL)(
+    IN struct _EFI_UDP4          *This,
+    IN EFI_UDP4_COMPLETION_TOKEN *Token OPTIONAL
+    );
+
+typedef
+EFI_STATUS
+(EFIAPI *EFI_UDP4_POLL) (
+    IN struct _EFI_UDP4 *This
+    );
+
+typedef struct _EFI_UDP4 {
+    EFI_UDP4_GET_MODE_DATA GetModeData;
+    EFI_UDP4_CONFIGURE     Configure;
+    EFI_UDP4_GROUPS        Groups;
+    EFI_UDP4_ROUTES        Routes;
+    EFI_UDP4_TRANSMIT      Transmit;
+    EFI_UDP4_RECEIVE       Receive;
+    EFI_UDP4_CANCEL        Cancel;
+    EFI_UDP4_POLL          Poll;
+} EFI_UDP4;
+
+typedef struct {
+    BOOLEAN          AcceptPromiscuous;
+    BOOLEAN          AcceptAnyPort;
+    BOOLEAN          AllowDuplicatePort;
+    UINT8            TrafficClass;
+    UINT8            HopLimit;
+    UINT32           ReceiveTimeout;
+    UINT32           TransmitTimeout;
+    EFI_IPv6_ADDRESS StationAddress;
+    UINT16           StationPort;
+    EFI_IPv6_ADDRESS RemoteAddress;
+    UINT16           RemotePort;
+} EFI_UDP6_CONFIG_DATA;
+
+typedef
+EFI_STATUS
+(EFIAPI *EFI_UDP6_GET_MODE_DATA) (
+    IN struct _EFI_UDP6                 *This,
+    OUT EFI_UDP6_CONFIG_DATA            *Udp6ConfigData OPTIONAL,
+    OUT EFI_IP6_MODE_DATA               *Ip6ModeData    OPTIONAL,
+    OUT EFI_MANAGED_NETWORK_CONFIG_DATA *MnpConfigData  OPTIONAL,
+    OUT EFI_SIMPLE_NETWORK_MODE         *SnpModeData    OPTIONAL
+    );
+
+typedef
+EFI_STATUS
+(EFIAPI *EFI_UDP6_CONFIGURE) (
+    IN struct _EFI_UDP6     *This,
+    IN EFI_UDP6_CONFIG_DATA *UdpConfigData OPTIONAL
+    );
+
+typedef
+EFI_STATUS
+(EFIAPI *EFI_UDP6_GROUPS) (
+    IN struct _EFI_UDP6 *This,
+    IN BOOLEAN          JoinFlag,
+    IN EFI_IPv6_ADDRESS *MulticastAddress OPTIONAL
+    );
+
+typedef struct {
+    EFI_IPv6_ADDRESS SourceAddress;
+    UINT16           SourcePort;
+    EFI_IPv6_ADDRESS DestinationAddress;
+    UINT16           DestinationPort;
+} EFI_UDP6_SESSION_DATA;
+
+typedef struct {
+    UINT32 FragmentLength;
+    VOID   *FragmentBuffer;
+} EFI_UDP6_FRAGMENT_DATA;
+
+typedef struct {
+    EFI_TIME               TimeStamp;
+    EFI_EVENT              RecycleSignal;
+    EFI_UDP6_SESSION_DATA  UdpSession;
+    UINT32                 DataLength;
+    UINT32                 FragmentCount;
+    EFI_UDP6_FRAGMENT_DATA FragmentTable[1];
+} EFI_UDP6_RECEIVE_DATA;
+
+typedef struct {
+    EFI_UDP6_SESSION_DATA  *UdpSessionData;
+    UINT32                 DataLength;
+    UINT32                 FragmentCount;
+    EFI_UDP6_FRAGMENT_DATA FragmentTable[1];
+} EFI_UDP6_TRANSMIT_DATA;
+
+typedef struct {
+    EFI_EVENT                  Event;
+    EFI_STATUS                 Status;
+    union {
+        EFI_UDP6_RECEIVE_DATA  *RxData;
+        EFI_UDP6_TRANSMIT_DATA *TxData;
+    }                          Packet;
+} EFI_UDP6_COMPLETION_TOKEN;
+
+typedef
+EFI_STATUS
+(EFIAPI *EFI_UDP6_TRANSMIT) (
+    IN struct _EFI_UDP6          *This,
+    IN EFI_UDP6_COMPLETION_TOKEN *Token
+    );
+
+typedef
+EFI_STATUS
+(EFIAPI *EFI_UDP6_RECEIVE) (
+    IN struct _EFI_UDP6          *This,
+    IN EFI_UDP6_COMPLETION_TOKEN *Token
+    );
+
+typedef
+EFI_STATUS
+(EFIAPI *EFI_UDP6_CANCEL)(
+    IN struct _EFI_UDP6          *This,
+    IN EFI_UDP6_COMPLETION_TOKEN *Token OPTIONAL
+    );
+
+typedef
+EFI_STATUS
+(EFIAPI *EFI_UDP6_POLL) (
+    IN struct _EFI_UDP6 *This
+    );
+
+typedef struct _EFI_UDP6 {
+    EFI_UDP6_GET_MODE_DATA GetModeData;
+    EFI_UDP6_CONFIGURE     Configure;
+    EFI_UDP6_GROUPS        Groups;
+    EFI_UDP6_TRANSMIT      Transmit;
+    EFI_UDP6_RECEIVE       Receive;
+    EFI_UDP6_CANCEL        Cancel;
+    EFI_UDP6_POLL          Poll;
+} EFI_UDP6;
+
+#endif /* _EFI_UDP_H */

--- a/gnu-efi/efiui.h
+++ b/gnu-efi/efiui.h
@@ -1,0 +1,58 @@
+#ifndef _EFI_UI_H
+#define _EFI_UI_H
+
+/*++
+
+Copyright (c) 200  Intel Corporation
+
+Module Name:
+
+    EfiUi.h
+
+Abstract:
+    Protocol used to build User Interface (UI) stuff.
+
+    This protocol is just data. It is a multi dimentional array.
+    For each string there is an array of UI_STRING_ENTRY. Each string
+    is for a different language translation of the same string. The list
+    is terminated by a NULL UiString. There can be any number of
+    UI_STRING_ENTRY arrays. A NULL array terminates the list. A NULL array
+    entry contains all zeros.
+
+    Thus the shortest possible EFI_UI_PROTOCOL has three UI_STRING_ENTRY.
+    The String, it's NULL terminator, and the NULL terminator for the entire
+    thing.
+
+
+Revision History
+
+--*/
+
+#define EFI_UI_INTERFACE_PROTOCOL_GUID \
+    { 0x32dd7981, 0x2d27, 0x11d4, {0xbc, 0x8b, 0x0, 0x80, 0xc7, 0x3c, 0x88, 0x81} }
+#define EFI_UI_PROTOCOL EFI_UI_INTERFACE_PROTOCOL_GUID
+
+
+typedef enum {
+    UiDeviceString,
+    UiVendorString,
+    UiMaxString
+} UI_STRING_TYPE;
+
+typedef struct {
+    ISO_639_2   *LangCode;
+    CHAR16      *UiString;
+} UI_STRING_ENTRY;
+
+#define EFI_UI_INTERFACE_PROTOCOL_VERSION 0x00010000
+#define EFI_UI_VERSION                    EFI_UI_INTERFACE_PROTOCOL_VERSION
+
+typedef struct _EFI_UI_INTERFACE_PROTOCOL {
+    UINT32          Version;
+    UI_STRING_ENTRY *Entry;
+} EFI_UI_INTERFACE_PROTOCOL;
+
+typedef struct _EFI_UI_INTERFACE_PROTOCOL _UI_INTERFACE;
+typedef EFI_UI_INTERFACE_PROTOCOL UI_INTERFACE;
+
+#endif


### PR DESCRIPTION
CMakeLists.txt needed subdirectories for filesystems moved after gnu-efi inclusion as it is dependent.

Updated readme to include submodules when git cloning during Linux build instructions.

Added 13 additional files for support while compiling ntfs driver. Directly from https://github.com/pbatard/gnu-efi.

Added efishell.h from ^^^ for ^^^ required type edit on line 51 as EFI_LIST_ENTRY is not defined while LIST_ENTRY is defined in already included efilink.h.

Great project thank you for the hard work.